### PR TITLE
[008] fix(D-17): drop dead JSONEncoder field

### DIFF
--- a/encoder/factory_test.go
+++ b/encoder/factory_test.go
@@ -1,0 +1,61 @@
+package encoder
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/architagr/lognugget/enum"
+)
+
+// Test_DefaultEncoderFactory_KnownTypes covers TS-15: JSON and Text
+// resolve to non-nil encoders that honor the F7 Write contract.
+func Test_DefaultEncoderFactory_KnownTypes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   enum.LogEncodeType
+		want string
+	}{
+		{"json wraps", enum.EncoderJSON, "{a:1}"},
+		{"text passthrough", enum.EncoderText, "a:1"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			enc, err := DefaultEncoderFactory(tc.in)
+			if err != nil {
+				t.Fatalf("factory err: %v", err)
+			}
+			if enc == nil {
+				t.Fatal("factory returned nil encoder")
+			}
+			out, err := enc.Write("a:1")
+			if err != nil {
+				t.Fatalf("write err: %v", err)
+			}
+			if string(out) != tc.want {
+				t.Fatalf("got %q want %q", string(out), tc.want)
+			}
+		})
+	}
+}
+
+// Test_DefaultEncoderFactory_UnknownReturnsErr covers TS-18 partial:
+// the current factory rejects unknown types with ErrUnsupportedEncoderType.
+// why: story 008 spec line references "fallback to JSON" (D-10 doc ack) but
+// the actual code surface returns an error. ARCH-2/policy change is out of
+// scope here; this test pins current behavior so a future fallback flip is
+// a deliberate, reviewed change.
+func Test_DefaultEncoderFactory_UnknownReturnsErr(t *testing.T) {
+	t.Parallel()
+
+	enc, err := DefaultEncoderFactory(enum.LogEncodeType("bogus"))
+	if !errors.Is(err, ErrUnsupportedEncoderType) {
+		t.Fatalf("want ErrUnsupportedEncoderType, got %v", err)
+	}
+	if enc != nil {
+		t.Fatalf("want nil encoder on unknown, got %T", enc)
+	}
+}

--- a/encoder/json_encoder.go
+++ b/encoder/json_encoder.go
@@ -1,22 +1,19 @@
 package encoder
 
-import (
-	"encoding/json"
-)
-
+// NewJSONEncoder returns a JSON encoder that satisfies the F7 Write contract.
+// why: D-17 removed the unused *json.Encoder field; struct is now empty so
+// allocation cost on the hot path is zero.
 func NewJSONEncoder() Encoder {
-	// Implementation of JSON encoder
-	return &JSONEncoder{
-		jsonFormatter: json.NewEncoder(nil), // Replace nil with actual output writer
-	}
+	return &JSONEncoder{}
 }
 
-type JSONEncoder struct {
-	jsonFormatter *json.Encoder
-}
+// JSONEncoder wraps an entry's pre-formatted body in JSON object braces.
+// It holds no state; methods are safe for concurrent use.
+type JSONEncoder struct{}
 
+// Write returns entryData wrapped in "{...}". The F7 contract guarantees a
+// nil error for the in-process path; the signature retains error for ARCH-2
+// (story 015) when sinks may surface I/O failures.
 func (e *JSONEncoder) Write(entryData string) ([]byte, error) {
-	// Implementation of JSON encoding logic
-
 	return []byte("{" + entryData + "}"), nil
 }

--- a/encoder/json_encoder_test.go
+++ b/encoder/json_encoder_test.go
@@ -1,0 +1,33 @@
+package encoder
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Test_JSONEncoder_NoEmbeddedNilEncoder asserts JSONEncoder carries no
+// surviving fields — the dead *json.Encoder slot from D-17 is gone.
+func Test_JSONEncoder_NoEmbeddedNilEncoder(t *testing.T) {
+	t.Parallel()
+
+	enc := NewJSONEncoder()
+	v := reflect.ValueOf(enc).Elem()
+	if v.NumField() != 0 {
+		t.Fatalf("JSONEncoder must have zero fields after D-17; got %d", v.NumField())
+	}
+}
+
+// Test_JSONEncoder_Write_WrapsInBraces locks the externally observable
+// behavior: F7 contract Write(string) ([]byte, error) returns "{<in>}".
+func Test_JSONEncoder_Write_WrapsInBraces(t *testing.T) {
+	t.Parallel()
+
+	enc := NewJSONEncoder()
+	got, err := enc.Write("key:value")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "{key:value}" {
+		t.Fatalf("got %q, want %q", string(got), "{key:value}")
+	}
+}

--- a/encoder/json_encoder_test.go
+++ b/encoder/json_encoder_test.go
@@ -7,11 +7,17 @@ import (
 
 // Test_JSONEncoder_NoEmbeddedNilEncoder asserts JSONEncoder carries no
 // surviving fields — the dead *json.Encoder slot from D-17 is gone.
+// why: defensive against future refactors that may switch NewJSONEncoder
+// to return by value; reflect.Elem() only unwraps pointers, so we check
+// the kind before dereferencing (QA-security P3, PR #50 cycle 1).
 func Test_JSONEncoder_NoEmbeddedNilEncoder(t *testing.T) {
 	t.Parallel()
 
 	enc := NewJSONEncoder()
-	v := reflect.ValueOf(enc).Elem()
+	v := reflect.ValueOf(enc)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
 	if v.NumField() != 0 {
 		t.Fatalf("JSONEncoder must have zero fields after D-17; got %d", v.NumField())
 	}


### PR DESCRIPTION
Refs #20. Fixes D-17. Closes story 008.

## What
- Drop dead `jsonFormatter *json.Encoder` field from `JSONEncoder`. Was initialized via `json.NewEncoder(nil)` and never read.
- `JSONEncoder` is now `struct{}`. F7 contract `Write(string) ([]byte, error)` unchanged.
- Add `encoder/factory_test.go` covering TS-15 (JSON + Text resolve, write, F7 contract) and TS-18 partial (unknown type returns `ErrUnsupportedEncoderType` — pins current behavior; D-10 fallback flip is out of scope).
- Add `encoder/json_encoder_test.go` regression guard via `reflect.NumField()==0` and `Write` body lock.

## Field removed
- Type: `*encoding/json.Encoder`
- Name: `jsonFormatter`
- Initializer: `json.NewEncoder(nil)`

## Gates
- `go test ./encoder/...` green.
- `go test ./...` — encoder green; pre-existing failures in `entry/` package (`TestEntryForDebug...` / `TestEntryForError...` missing `custom.message`) are unrelated to D-17 and pre-date this branch (no entry/ touch in this PR).
- `golangci-lint run ./encoder/...` clean.
- `./.claude/scripts/bench-check.sh` not run — script absent in repo `.claude/`. Change is a pure dead-field removal; no allocation delta on the `Write` hot path is possible since the field was never read. Flagging to Project Lead.

## Notes
- Pre-fix run of `Test_JSONEncoder_NoEmbeddedNilEncoder` correctly FAILS (`got 1` field) — that's the regression guard's job. Brief said "pass before AND after"; pragmatic read is the guard test is RED→GREEN by design and the F7-contract tests are GREEN both. Surfacing for transparency.
- Tests written by prior (parent-verified) run; per brief I did not rewrite them. Combined test+impl LOC is ~104 (>80 cap) — overage comes from the parent-supplied test files, not the impl change (impl is +17/-7). Calling it out for Lead arbitration.

## Out of scope (per brief)
- ARCH-2 interface change (story 015).
- D-10 fallback-to-JSON policy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)