### PR TITLE
[001] TS-01 test/support builders

### DIFF
--- a/test/support/builders.go
+++ b/test/support/builders.go
@@ -1,0 +1,130 @@
+// Package support provides test builders and lightweight fakes/spies
+// for the lognugget logger. Test-only; consumed by *_test.go across
+// the module to keep arrange-phase setup terse and free of singleton
+// leak hazards (T-13).
+package support
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	"github.com/architagr/lognugget/model"
+)
+
+// ConfigBuilder applies a fluent chain of setters against the
+// process-wide config singleton, then registers a tb.Cleanup that
+// restores defaults at end of scope. Mitigates T-13.
+type ConfigBuilder struct {
+	tb testing.TB
+	// why: defer apply until Build() so partial state never leaks.
+	apply []func()
+}
+
+// NewConfigBuilder returns a builder bound to tb.
+func NewConfigBuilder(tb testing.TB) *ConfigBuilder {
+	tb.Helper()
+	return &ConfigBuilder{tb: tb}
+}
+
+// MinLevel queues SetMinLevel.
+func (b *ConfigBuilder) MinLevel(l enum.LogLevel) *ConfigBuilder {
+	b.apply = append(b.apply, func() { config.SetMinLevel(l) })
+	return b
+}
+
+// Encoder queues SetEncoderType.
+func (b *ConfigBuilder) Encoder(e enum.LogEncodeType) *ConfigBuilder {
+	b.apply = append(b.apply, func() { config.SetEncoderType(e) })
+	return b
+}
+
+// Output queues SetOutput.
+func (b *ConfigBuilder) Output(w io.Writer) *ConfigBuilder {
+	b.apply = append(b.apply, func() { config.SetOutput(w) })
+	return b
+}
+
+// AddSource queues SetAddSource.
+func (b *ConfigBuilder) AddSource(v bool) *ConfigBuilder {
+	b.apply = append(b.apply, func() { config.SetAddSource(v) })
+	return b
+}
+
+// Build applies queued setters and returns a cleanup func that resets
+// the singleton; cleanup is also registered via tb.Cleanup.
+func (b *ConfigBuilder) Build() func() {
+	b.tb.Helper()
+	for _, fn := range b.apply {
+		fn()
+	}
+	cleanup := func() { config.ResetConfig() }
+	b.tb.Cleanup(cleanup)
+	return cleanup
+}
+
+// EntryBuilder records inputs (ctx, err, fields) for *entry.LogEntry
+// methods and exposes them for assertions.
+type EntryBuilder struct {
+	ctx    context.Context
+	err    error
+	fields []model.LogAttr
+}
+
+// NewEntryBuilder returns a fresh EntryBuilder.
+func NewEntryBuilder() *EntryBuilder { return &EntryBuilder{} }
+
+// WithFields generates n synthetic LogAttr entries with distinct keys
+// "k0".."k{n-1}".
+func (b *EntryBuilder) WithFields(n int) *EntryBuilder {
+	b.fields = make([]model.LogAttr, n)
+	for i := 0; i < n; i++ {
+		b.fields[i] = model.LogAttr{Key: model.LogAttrKey(fmt.Sprintf("k%d", i)), Value: i}
+	}
+	return b
+}
+
+// WithCtx stores ctx for retrieval via Ctx().
+func (b *EntryBuilder) WithCtx(ctx context.Context) *EntryBuilder { b.ctx = ctx; return b }
+
+// WithErr stores err for retrieval via Err().
+func (b *EntryBuilder) WithErr(err error) *EntryBuilder { b.err = err; return b }
+
+// Fields returns the recorded attrs.
+func (b *EntryBuilder) Fields() []model.LogAttr { return b.fields }
+
+// Ctx returns the recorded context (may be nil).
+func (b *EntryBuilder) Ctx() context.Context { return b.ctx }
+
+// Err returns the recorded error (may be nil).
+func (b *EntryBuilder) Err() error { return b.err }
+
+// Build returns a fresh *entry.LogEntry from the entry pool. Recorded
+// ctx/err/fields are not bound here — LogEntry's fields are unexported,
+// so callers pass them at the Log/Info/Error call site themselves.
+func (b *EntryBuilder) Build() *entry.LogEntry { return entry.NewLogEntry() }
+
+// EventBuilder constructs config.LogEvent values for tests that bypass
+// the full logger entrypoint.
+type EventBuilder struct {
+	level enum.LogLevel
+	data  []byte
+}
+
+// NewEventBuilder returns a builder defaulting to LevelInfo.
+func NewEventBuilder() *EventBuilder { return &EventBuilder{level: enum.LevelInfo} }
+
+// Level overrides the event level.
+func (b *EventBuilder) Level(l enum.LogLevel) *EventBuilder { b.level = l; return b }
+
+// Body overrides the event payload.
+func (b *EventBuilder) Body(data []byte) *EventBuilder { b.data = data; return b }
+
+// Build returns a config.LogEvent populated from recorded fields.
+func (b *EventBuilder) Build() config.LogEvent {
+	return config.LogEvent{Level: b.level, Data: b.data}
+}

--- a/test/support/builders_test.go
+++ b/test/support/builders_test.go
@@ -1,0 +1,118 @@
+// Package support_test exercises the test/support helpers.
+package support_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/enum"
+	"github.com/architagr/lognugget/test/support"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_NewConfigBuilder_ChainsAllSettersAndCleansUp verifies that the
+// ConfigBuilder applies every setter, that Build() returns a cleanup
+// function, and that the cleanup is registered with t.Cleanup so the
+// singleton resets between tests (acceptance #1, #7, #8).
+func Test_NewConfigBuilder_ChainsAllSettersAndCleansUp(t *testing.T) {
+	t.Parallel()
+
+	var buf testWriter
+	tb := newRecordingTB(t)
+	cleanup := support.NewConfigBuilder(tb).
+		MinLevel(enum.LevelError).
+		Encoder(enum.EncoderText).
+		Output(&buf).
+		AddSource(false).
+		Build()
+
+	require.NotNil(t, cleanup, "Build must return a non-nil cleanup func")
+
+	cfg := config.GetConfig()
+	assert.Equal(t, enum.LevelError, cfg.MinLevel())
+	assert.Equal(t, enum.EncoderText, cfg.EncoderType())
+	assert.False(t, cfg.AddSource())
+	assert.Same(t, io.Writer(&buf), cfg.Output())
+
+	require.Len(t, tb.cleanups, 1, "Build must register exactly one t.Cleanup")
+
+	// Run the cleanup; it must restore singleton defaults so the next test sees a fresh state.
+	cleanup()
+	cfg = config.GetConfig()
+	assert.Equal(t, config.DafaultLevel, cfg.MinLevel(), "cleanup must restore default min-level")
+	assert.Equal(t, config.DafaultEncoderType, cfg.EncoderType(), "cleanup must restore default encoder")
+	assert.Equal(t, config.DafaultAddSource, cfg.AddSource(), "cleanup must restore default addSource")
+}
+
+// Test_ConfigBuilder_TBCleanupRunsAutomatically asserts the cleanup
+// registered with tb.Cleanup actually fires when the test scope ends,
+// guarding against the T-13 singleton-leak class of bug.
+func Test_ConfigBuilder_TBCleanupRunsAutomatically(t *testing.T) {
+	t.Parallel()
+
+	tb := newRecordingTB(t)
+	support.NewConfigBuilder(tb).MinLevel(enum.LevelWarn).Build()
+	require.Len(t, tb.cleanups, 1)
+
+	tb.runCleanups()
+
+	assert.Equal(t, config.DafaultLevel, config.GetConfig().MinLevel())
+}
+
+// Test_EntryBuilder_AppliesAllOptions covers acceptance #2: the chainable
+// EntryBuilder records ctx, err, and N synthetic fields, and Build()
+// returns a usable *entry.LogEntry.
+func Test_EntryBuilder_AppliesAllOptions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.WithValue(context.Background(), ctxKey("k"), "v")
+	bootErr := errors.New("boom")
+
+	b := support.NewEntryBuilder().
+		WithFields(5).
+		WithCtx(ctx).
+		WithErr(bootErr)
+
+	assert.Len(t, b.Fields(), 5, "WithFields(n) must produce n attrs")
+	assert.Same(t, ctx, b.Ctx(), "WithCtx must store the context")
+	assert.Same(t, bootErr, b.Err(), "WithErr must store the error")
+
+	got := b.Build()
+	require.NotNil(t, got, "Build must return a non-nil *entry.LogEntry")
+}
+
+// Test_EntryBuilder_FieldsHaveDistinctKeys protects against accidental
+// key collisions in the synthetic field generator — important for any
+// downstream test that asserts on N distinct fields.
+func Test_EntryBuilder_FieldsHaveDistinctKeys(t *testing.T) {
+	t.Parallel()
+
+	b := support.NewEntryBuilder().WithFields(8)
+	seen := make(map[string]struct{}, 8)
+	for _, f := range b.Fields() {
+		_, dup := seen[string(f.Key)]
+		assert.False(t, dup, "field key %q duplicated", f.Key)
+		seen[string(f.Key)] = struct{}{}
+	}
+}
+
+// Test_EventBuilder_ProducesLogEvent covers acceptance #3.
+func Test_EventBuilder_ProducesLogEvent(t *testing.T) {
+	t.Parallel()
+
+	ev := support.NewEventBuilder().
+		Level(enum.LevelWarn).
+		Body([]byte("hello")).
+		Build()
+
+	assert.Equal(t, enum.LevelWarn, ev.Level)
+	assert.Equal(t, []byte("hello"), ev.Data)
+}
+
+// ctxKey is a typed key to avoid the lint warning about string keys in
+// context.WithValue.
+type ctxKey string

--- a/test/support/fakes.go
+++ b/test/support/fakes.go
@@ -1,0 +1,134 @@
+package support
+
+import (
+	"sync"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/enum"
+)
+
+// FakeWriter is a thread-safe io.Writer that records every byte
+// written and the number of Write calls.
+type FakeWriter struct {
+	mu    sync.Mutex
+	buf   []byte
+	count int
+}
+
+// NewFakeWriter returns a zero-state FakeWriter.
+func NewFakeWriter() *FakeWriter { return &FakeWriter{} }
+
+// Write appends p, bumps the call counter, returns (len(p), nil).
+func (w *FakeWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf = append(w.buf, p...)
+	w.count++
+	return len(p), nil
+}
+
+// Bytes returns a copy of every byte ever written.
+// why: copy prevents callers corrupting fake state via slice aliasing.
+func (w *FakeWriter) Bytes() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]byte, len(w.buf))
+	copy(out, w.buf)
+	return out
+}
+
+// Count returns the number of Write calls observed.
+func (w *FakeWriter) Count() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.count
+}
+
+// SpyHook is a chan-backed config.PublishLogMessageHookContract that
+// records published payloads in FIFO order. Bounded buffer; overflow
+// is dropped (not blocked) to keep producers deterministic.
+type SpyHook struct {
+	name    string
+	records chan config.LogEvent
+}
+
+// NewSpyHook returns a SpyHook with name and buffer capacity (>=1).
+func NewSpyHook(name string, capacity int) *SpyHook {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &SpyHook{name: name, records: make(chan config.LogEvent, capacity)}
+}
+
+// Name reports the hook name.
+func (h *SpyHook) Name() string { return h.name }
+
+// PublishLogMessage records entry; drops silently if buffer is full.
+// why: copy so a producer reusing its buffer cannot mutate what tests
+// later assert on.
+func (h *SpyHook) PublishLogMessage(entry []byte) {
+	cp := make([]byte, len(entry))
+	copy(cp, entry)
+	select {
+	case h.records <- config.LogEvent{Data: cp}:
+	default:
+	}
+}
+
+// Next blocks until a record is available or the channel closes.
+func (h *SpyHook) Next() (config.LogEvent, bool) {
+	ev, ok := <-h.records
+	return ev, ok
+}
+
+// NextNonBlocking returns the next record if immediately available.
+func (h *SpyHook) NextNonBlocking() (config.LogEvent, bool) {
+	select {
+	case ev, ok := <-h.records:
+		return ev, ok
+	default:
+		return config.LogEvent{}, false
+	}
+}
+
+// FakePreProcRecord captures a single PreProcess invocation.
+type FakePreProcRecord struct {
+	Level enum.LogLevel
+	Data  []byte
+}
+
+// FakePreProc records every PreProcess invocation in order. Satisfies
+// the (unexported) preProcessingObserverContract in package config via
+// structural typing.
+//
+// LIMITATION: upstream contract is unexported; update this fake in
+// lock step if its method set changes.
+type FakePreProc struct {
+	mu   sync.Mutex
+	name string
+	recs []FakePreProcRecord
+}
+
+// NewFakePreProc returns a FakePreProc with the given name.
+func NewFakePreProc(name string) *FakePreProc { return &FakePreProc{name: name} }
+
+// Name reports the processor name.
+func (p *FakePreProc) Name() string { return p.name }
+
+// PreProcess records (level, data); data is defensively copied.
+func (p *FakePreProc) PreProcess(level enum.LogLevel, logMsg []byte) {
+	cp := make([]byte, len(logMsg))
+	copy(cp, logMsg)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.recs = append(p.recs, FakePreProcRecord{Level: level, Data: cp})
+}
+
+// Records returns a snapshot copy of every invocation in call order.
+func (p *FakePreProc) Records() []FakePreProcRecord {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]FakePreProcRecord, len(p.recs))
+	copy(out, p.recs)
+	return out
+}

--- a/test/support/fakes.go
+++ b/test/support/fakes.go
@@ -45,7 +45,9 @@ func (w *FakeWriter) Count() int {
 }
 
 // SpyHook is a chan-backed config.PublishLogMessageHookContract that
-// records published payloads in FIFO order.
+// records published payloads in FIFO order. The contract surface is
+// PublishLogMessage([]byte) only — level is not propagated by the
+// upstream hook contract.
 //
 // Buffering is bounded: once the channel is full, further publishes
 // are dropped silently (never block the producer). Callers MUST size

--- a/test/support/fakes.go
+++ b/test/support/fakes.go
@@ -45,14 +45,23 @@ func (w *FakeWriter) Count() int {
 }
 
 // SpyHook is a chan-backed config.PublishLogMessageHookContract that
-// records published payloads in FIFO order. Bounded buffer; overflow
-// is dropped (not blocked) to keep producers deterministic.
+// records published payloads in FIFO order.
+//
+// Buffering is bounded: once the channel is full, further publishes
+// are dropped silently (never block the producer). Callers MUST size
+// the capacity at construction time to be at least the number of
+// events the test expects to observe; oversize is harmless, undersize
+// causes lost records.
 type SpyHook struct {
 	name    string
 	records chan config.LogEvent
 }
 
-// NewSpyHook returns a SpyHook with name and buffer capacity (>=1).
+// NewSpyHook returns a SpyHook with the given name and buffer
+// capacity. Any capacity < 1 is silently raised to 1 so the zero
+// value is usable; tests that need "always block" semantics are not
+// supported by this fake — pick a capacity sized to the expected
+// event count instead.
 func NewSpyHook(name string, capacity int) *SpyHook {
 	if capacity < 1 {
 		capacity = 1

--- a/test/support/fakes_test.go
+++ b/test/support/fakes_test.go
@@ -1,0 +1,124 @@
+package support_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/architagr/lognugget/enum"
+	"github.com/architagr/lognugget/test/support"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_FakeWriter_BytesAndCount_Sequential verifies the basic Fake
+// contract for acceptance #4: Write appends; Bytes returns a copy of
+// every byte ever written; Count tracks Write calls.
+func Test_FakeWriter_BytesAndCount_Sequential(t *testing.T) {
+	t.Parallel()
+
+	w := support.NewFakeWriter()
+	n, err := w.Write([]byte("alpha"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+
+	_, err = w.Write([]byte("beta"))
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, w.Count(), "Count must equal number of Write calls")
+	assert.Equal(t, []byte("alphabeta"), w.Bytes(), "Bytes must return concatenated payload")
+}
+
+// Test_FakeWriter_BytesReturnsCopy guards against callers mutating the
+// internal buffer through the returned slice (T-13-style hygiene).
+func Test_FakeWriter_BytesReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	w := support.NewFakeWriter()
+	_, _ = w.Write([]byte("xy"))
+	got := w.Bytes()
+	got[0] = 'Z'
+
+	assert.Equal(t, []byte("xy"), w.Bytes(), "mutating returned slice must not affect FakeWriter state")
+}
+
+// Test_FakeWriter_ConcurrentSafe exercises the mu-guard requirement of
+// acceptance #4: the writer must survive parallel writers under -race.
+func Test_FakeWriter_ConcurrentSafe(t *testing.T) {
+	t.Parallel()
+
+	const writers = 16
+	const perWriter = 64
+
+	w := support.NewFakeWriter()
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perWriter; j++ {
+				_, _ = w.Write([]byte("x"))
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, writers*perWriter, w.Count())
+	assert.Len(t, w.Bytes(), writers*perWriter)
+}
+
+// Test_SpyHook_RecordsOrderedAndExposesName covers acceptance #5:
+// SpyHook is chan-backed, records (level, payload) entries, and
+// satisfies the public hook contract.
+func Test_SpyHook_RecordsOrderedAndExposesName(t *testing.T) {
+	t.Parallel()
+
+	hook := support.NewSpyHook("spy-1", 4)
+	assert.Equal(t, "spy-1", hook.Name())
+
+	hook.PublishLogMessage([]byte("first"))
+	hook.PublishLogMessage([]byte("second"))
+
+	got1, ok1 := hook.Next()
+	require.True(t, ok1, "Next must return the first record")
+	assert.Equal(t, []byte("first"), got1.Data)
+
+	got2, ok2 := hook.Next()
+	require.True(t, ok2)
+	assert.Equal(t, []byte("second"), got2.Data)
+}
+
+// Test_SpyHook_DropsBeyondCapacity asserts the chan-backed buffer
+// drops new records once full instead of blocking the producer; this
+// keeps tests deterministic when wired into hook fan-out paths.
+func Test_SpyHook_DropsBeyondCapacity(t *testing.T) {
+	t.Parallel()
+
+	hook := support.NewSpyHook("cap", 1)
+	hook.PublishLogMessage([]byte("kept"))
+	hook.PublishLogMessage([]byte("dropped"))
+
+	got, ok := hook.Next()
+	require.True(t, ok)
+	assert.Equal(t, []byte("kept"), got.Data)
+
+	_, ok = hook.NextNonBlocking()
+	assert.False(t, ok, "second record must have been dropped, not buffered")
+}
+
+// Test_FakePreProc_RecordsAllInvocations covers acceptance #6.
+func Test_FakePreProc_RecordsAllInvocations(t *testing.T) {
+	t.Parallel()
+
+	pp := support.NewFakePreProc("pp")
+	assert.Equal(t, "pp", pp.Name())
+
+	pp.PreProcess(enum.LevelInfo, []byte("a"))
+	pp.PreProcess(enum.LevelError, []byte("b"))
+
+	rec := pp.Records()
+	require.Len(t, rec, 2)
+	assert.Equal(t, enum.LevelInfo, rec[0].Level)
+	assert.Equal(t, []byte("a"), rec[0].Data)
+	assert.Equal(t, enum.LevelError, rec[1].Level)
+	assert.Equal(t, []byte("b"), rec[1].Data)
+}

--- a/test/support/helpers_test.go
+++ b/test/support/helpers_test.go
@@ -1,0 +1,50 @@
+package support_test
+
+import (
+	"sync"
+	"testing"
+)
+
+// testWriter is a minimal io.Writer used as a sentinel in
+// ConfigBuilder tests — only its identity matters, not its contents.
+type testWriter struct{ buf []byte }
+
+func (w *testWriter) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+	return len(p), nil
+}
+
+// recordingTB wraps testing.TB and captures Cleanup callbacks instead
+// of registering them with the underlying *testing.T. This lets us
+// assert that the ConfigBuilder registers exactly one cleanup, and
+// invoke that cleanup deterministically inside the test body rather
+// than waiting for the test scope to unwind.
+type recordingTB struct {
+	testing.TB
+	mu       sync.Mutex
+	cleanups []func()
+}
+
+func newRecordingTB(t *testing.T) *recordingTB {
+	return &recordingTB{TB: t}
+}
+
+// Cleanup overrides testing.TB.Cleanup so the registered fn lands in
+// the recordingTB's slice instead of the real t's stack.
+func (r *recordingTB) Cleanup(fn func()) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cleanups = append(r.cleanups, fn)
+}
+
+// runCleanups invokes every captured cleanup in LIFO order, mirroring
+// testing.T's documented semantics.
+func (r *recordingTB) runCleanups() {
+	r.mu.Lock()
+	fns := r.cleanups
+	r.cleanups = nil
+	r.mu.Unlock()
+	for i := len(fns) - 1; i >= 0; i-- {
+		fns[i]()
+	}
+}


### PR DESCRIPTION
Refs #13. Closes story 001.

## Summary

- `test/support/builders.go` — `ConfigBuilder` (T-13 mitigation via `tb.Cleanup`-bound `ResetConfig`), `EntryBuilder`, `EventBuilder`.
- `test/support/fakes.go` — `FakeWriter` (mu-guarded), `SpyHook` (chan-backed FIFO, drop-on-overflow), `FakePreProc` (mu-guarded record log).
- `test/support/helpers_test.go` — `testWriter`, `recordingTB` shim that captures `tb.Cleanup` calls so the cleanup-registration count can be asserted deterministically.

## Test results

- `go test ./test/support/...` — green
- `go test ./...` — pre-existing failures in `entry/` (`TestEntryForDebugWithMinLogLevelAsDebug`, `TestEntryForErrorWithMinLogLevelAsDebug`) unrelated to this PR; baseline `feat/12-lognugget-v1` already fails. Not introduced here.
- `go test -race ./test/support/...` — fails. The races are 100% inside the production `config` package: `ResetConfig()` writes `defaultConfig`/`ch`/`EventPreProcessors` while the goroutine spawned by `ResetConfig` itself (`ProcessLogEvent`) reads them. Triggered by the approved `t.Parallel()` tests calling `config.SetMinLevel` etc. concurrently with cleanup. **Outside this story's scope** — flagging for Project Lead.
- `golangci-lint run ./test/support/...` — clean
- `go vet ./test/support/...` — clean
- `go doc ./test/support` — clean

## Caveats / asks for the Project Lead

1. **LOC budget overrun.** Story constraint is ≤ 300 LOC total (tests + impl). The pre-approved tests alone are 242 LOC; impl + helpers_test add 314 LOC; total 556. I trimmed the impl as far as I could without losing GoDoc coverage on every exported identifier (`revive` `exported` rule). If 300 is hard, the only lever is shrinking the tests, which I was instructed to trust. Please decide.
2. **`config` package data race** (above) blocks `-race` runs of `test/support`. Suggest a follow-up story to put `defaultConfig`/`ch`/`EventPreProcessors` behind a `sync.RWMutex` or an `atomic.Pointer`. Until then, the `t.Parallel()` calls in `builders_test.go` will keep racing with whichever test runs `ResetConfig` next.
3. **`FakePreProc` and the unexported contract.** `config.preProcessingObserverContract` is unexported; `FakePreProc` satisfies it by structural typing only. Documented as `// LIMITATION:` in `fakes.go` so future maintainers see it.
4. **`bench-check.sh` not run** — script does not exist in this worktree (no `.claude/scripts/`). Test-support is not on a hot path so no benchmarks are added here.

## Files touched

- `test/support/builders.go` (new, 130 LOC)
- `test/support/fakes.go` (new, 134 LOC)
- `test/support/builders_test.go` (new, 118 LOC — already approved)
- `test/support/fakes_test.go` (new, 124 LOC — already approved)
- `test/support/helpers_test.go` (new, 50 LOC)