### PR TITLE
[002] TS-02 test/support doubles

### DIFF
--- a/test/support/doubles.go
+++ b/test/support/doubles.go
@@ -1,0 +1,204 @@
+package support
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/encoder"
+)
+
+// SlowHook implements config.PublishLogMessageHookContract and blocks
+// PublishLogMessage until Release is invoked. Drives F22/F23
+// backpressure tests; T-1 mitigation removes time.Sleep waits.
+type SlowHook struct {
+	name    string
+	gate    chan struct{}
+	mu      sync.Mutex
+	records [][]byte
+}
+
+// NewSlowHook returns a SlowHook with a closed-on-Release gate.
+func NewSlowHook(name string) *SlowHook {
+	return &SlowHook{name: name, gate: make(chan struct{})}
+}
+
+// Name reports the hook name.
+func (h *SlowHook) Name() string { return h.name }
+
+// PublishLogMessage records entry then blocks until Release is called.
+// why: defensive copy so the producer can reuse its buffer.
+func (h *SlowHook) PublishLogMessage(entry []byte) {
+	cp := append([]byte(nil), entry...)
+	h.mu.Lock()
+	h.records = append(h.records, cp)
+	h.mu.Unlock()
+	<-h.gate
+}
+
+// Release unblocks every current and future PublishLogMessage call.
+func (h *SlowHook) Release() { close(h.gate) }
+
+// Records returns a snapshot of every payload observed.
+func (h *SlowHook) Records() [][]byte {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([][]byte(nil), h.records...)
+}
+
+// FakePostProcessor implements the hook contract with no IO and
+// exposes recorded payloads via Got.
+type FakePostProcessor struct {
+	name string
+	mu   sync.Mutex
+	recs [][]byte
+}
+
+// NewFakePostProcessor returns a FakePostProcessor with the given name.
+func NewFakePostProcessor(name string) *FakePostProcessor {
+	return &FakePostProcessor{name: name}
+}
+
+// Name reports the processor name.
+func (p *FakePostProcessor) Name() string { return p.name }
+
+// PublishLogMessage records a defensive copy of entry.
+func (p *FakePostProcessor) PublishLogMessage(entry []byte) {
+	cp := append([]byte(nil), entry...)
+	p.mu.Lock()
+	p.recs = append(p.recs, cp)
+	p.mu.Unlock()
+}
+
+// Got returns deep copies of every recorded payload so callers cannot
+// mutate fake state via slice aliasing.
+func (p *FakePostProcessor) Got() [][]byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([][]byte, len(p.recs))
+	for i, b := range p.recs {
+		out[i] = append([]byte(nil), b...)
+	}
+	return out
+}
+
+// StubContextParser produces a config.ContextFieldsParser that returns
+// a fixed map and counts parser invocations.
+type StubContextParser struct {
+	fixed map[string]any
+	mu    sync.Mutex
+	calls int
+}
+
+// NewStubContextParser returns a stub bound to fixed.
+func NewStubContextParser(fixed map[string]any) *StubContextParser {
+	return &StubContextParser{fixed: fixed}
+}
+
+// Parser returns a closure that records calls and returns fixed.
+func (s *StubContextParser) Parser() config.ContextFieldsParser {
+	return func(_ context.Context) map[string]any {
+		s.mu.Lock()
+		s.calls++
+		s.mu.Unlock()
+		return s.fixed
+	}
+}
+
+// Calls returns the number of parser invocations.
+func (s *StubContextParser) Calls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// StubStaticParser produces a config.StaticEnvFieldsParser that returns
+// a fixed map and asserts the source is sampled exactly once across
+// any number of parser invocations (F15).
+type StubStaticParser struct {
+	fixed       map[string]any
+	mu          sync.Mutex
+	cached      map[string]any
+	evaluations int
+}
+
+// NewStubStaticParser returns a stub bound to fixed.
+func NewStubStaticParser(fixed map[string]any) *StubStaticParser {
+	return &StubStaticParser{fixed: fixed}
+}
+
+// Parser returns a memoising config.StaticEnvFieldsParser closure.
+// why: F15 requires once-only evaluation regardless of call count.
+func (s *StubStaticParser) Parser() config.StaticEnvFieldsParser {
+	return func() map[string]any {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.cached == nil {
+			s.evaluations++
+			s.cached = s.fixed
+		}
+		return s.cached
+	}
+}
+
+// Evaluations returns the count of underlying-source evaluations.
+func (s *StubStaticParser) Evaluations() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.evaluations
+}
+
+// StubEncoder implements encoder.Encoder with a passthrough Write that
+// returns the body verbatim and records every call. Isolates pipeline
+// tests from real-encoder churn (F10).
+type StubEncoder struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+// NewStubEncoder returns a zero-state StubEncoder.
+func NewStubEncoder() *StubEncoder { return &StubEncoder{} }
+
+// Write records body and returns it as raw bytes; never errors.
+func (s *StubEncoder) Write(body string) ([]byte, error) {
+	s.mu.Lock()
+	s.calls = append(s.calls, body)
+	s.mu.Unlock()
+	return []byte(body), nil
+}
+
+// Calls returns the recorded Write inputs in call order.
+func (s *StubEncoder) Calls() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.calls...)
+}
+
+var _ encoder.Encoder = (*StubEncoder)(nil)
+
+// FakeClock returns a deterministic time pinned to
+// 2026-01-02T03:04:05Z, required for stable golden-master output.
+type FakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+// NewFakeClock returns a FakeClock pinned to 2026-01-02T03:04:05Z.
+func NewFakeClock() *FakeClock {
+	return &FakeClock{now: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)}
+}
+
+// Now returns the pinned instant.
+func (c *FakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+// Advance shifts the pinned instant forward by d.
+func (c *FakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}

--- a/test/support/doubles.go
+++ b/test/support/doubles.go
@@ -1,3 +1,5 @@
+//go:build testing
+
 package support
 
 import (

--- a/test/support/doubles_test.go
+++ b/test/support/doubles_test.go
@@ -1,0 +1,108 @@
+package support_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/test/support"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_SlowHook_BlocksUntilRelease covers acceptance #1.
+func Test_SlowHook_BlocksUntilRelease(t *testing.T) {
+	t.Parallel()
+	hook := support.NewSlowHook("slow-1")
+	assert.Equal(t, "slow-1", hook.Name())
+
+	done := make(chan struct{})
+	go func() { hook.PublishLogMessage([]byte("payload")); close(done) }()
+
+	select {
+	case <-done:
+		t.Fatal("PublishLogMessage returned before Release()")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	hook.Release()
+	assert.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 5*time.Millisecond)
+
+	got := hook.Records()
+	require.Len(t, got, 1)
+	assert.Equal(t, []byte("payload"), got[0])
+}
+
+// Test_FakePostProcessor_GotReturnsCopies covers acceptance #2.
+func Test_FakePostProcessor_GotReturnsCopies(t *testing.T) {
+	t.Parallel()
+	pp := support.NewFakePostProcessor("pp")
+	assert.Equal(t, "pp", pp.Name())
+
+	pp.PublishLogMessage([]byte("a"))
+	pp.PublishLogMessage([]byte("b"))
+
+	got := pp.Got()
+	require.Len(t, got, 2)
+	assert.Equal(t, []byte("a"), got[0])
+	assert.Equal(t, []byte("b"), got[1])
+
+	got[0][0] = 'Z'
+	assert.Equal(t, []byte("a"), pp.Got()[0], "Got must return defensive copies")
+}
+
+// Test_StubContextParser_ReturnsFixedAndCounts covers acceptance #3.
+func Test_StubContextParser_ReturnsFixedAndCounts(t *testing.T) {
+	t.Parallel()
+	want := map[string]any{"trace": "abc", "user": 7}
+	stub := support.NewStubContextParser(want)
+
+	parser := stub.Parser()
+	assert.Equal(t, want, parser(context.Background()))
+	assert.Equal(t, want, parser(context.TODO()))
+	assert.Equal(t, 2, stub.Calls())
+}
+
+// Test_StubStaticParser_EvaluatesOnce covers acceptance #4 / F15.
+func Test_StubStaticParser_EvaluatesOnce(t *testing.T) {
+	t.Parallel()
+	want := map[string]any{"env": "test"}
+	stub := support.NewStubStaticParser(want)
+
+	parser := stub.Parser()
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, want, parser())
+	}
+	assert.Equal(t, 1, stub.Evaluations(), "F15: static parser must be evaluated once")
+}
+
+// Test_StubEncoder_WritePassthrough covers acceptance #5.
+func Test_StubEncoder_WritePassthrough(t *testing.T) {
+	t.Parallel()
+	enc := support.NewStubEncoder()
+	out, err := enc.Write("hello")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), out)
+
+	_, _ = enc.Write("world")
+	assert.Equal(t, []string{"hello", "world"}, enc.Calls())
+}
+
+// Test_FakeClock_NowDeterministic covers acceptance #6.
+func Test_FakeClock_NowDeterministic(t *testing.T) {
+	t.Parallel()
+	clk := support.NewFakeClock()
+	want := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	assert.Equal(t, want, clk.Now())
+	assert.Equal(t, want, clk.Now(), "Now must remain pinned across calls")
+
+	clk.Advance(time.Second)
+	assert.Equal(t, want.Add(time.Second), clk.Now(), "Advance must shift the pinned instant")
+}

--- a/test/support/doubles_test.go
+++ b/test/support/doubles_test.go
@@ -1,3 +1,5 @@
+//go:build testing
+
 package support_test
 
 import (


### PR DESCRIPTION
Refs #14. Closes story 002. Extends test/support catalog from story 001.

## Scope

Adds 6 doubles per `docs/lld/test-framework.md` §6:

- `SlowHook` — blocks `PublishLogMessage` until `Release()`. Drives F22/F23 backpressure tests; T-1 mitigation (replaces `time.Sleep` waits).
- `FakePostProcessor` — no-IO hook contract; `Got()` returns deep copies.
- `StubContextParser` — fixed map + invocation count.
- `StubStaticParser` — fixed map + once-only evaluation guarantee (F15).
- `StubEncoder` — passthrough `Write(string) ([]byte, error)`; satisfies `encoder.Encoder` (real interface, not the `Append` shape sketched in the story — matched real signature so tests can wire it in).
- `FakeClock` — pinned to `2026-01-02T03:04:05Z`; `Advance(d)` for time-based tests.

## Files

- `test/support/doubles.go` (NEW, 204 LOC)
- `test/support/doubles_test.go` (NEW, 108 LOC; one test per acceptance criterion)

## Gates

- `go test ./test/support/...` — GREEN.
- `go build ./...` / `go vet ./test/support/...` — clean.
- `go test -race ./test/support/...` — fails on PRE-EXISTING `config.ResetConfig` race (issue #54). My doubles introduce no new races; race trace lands in `config/config.go:252` via `ConfigBuilder.Build`. Per task brief: not fixed here.
- `go test ./...` — pre-existing `entry/` failures unrelated to this story.
- `golangci-lint` — binary not on PATH locally; CI will enforce.

## LOC overage — PL arbitration needed

Story cap is 200 LOC total (tests + impl). Delivered: 312 LOC (204 impl + 108 tests).

Six doubles, each requiring struct + GoDoc + constructor + 2-4 methods (with mandatory GoDoc per role spec) lands at ~30 LOC each baseline. The role's "Documentation standards (mandatory)" forbids dropping exported-identifier GoDocs, so further reduction would require sacrificing doc compliance.

Options:
1. Accept overage (recommended; story sizing was optimistic).
2. Split: ship `SlowHook` + `FakePostProcessor` here, defer the three Stubs + FakeClock to a follow-up. Drawback: TS-13/TS-14/TS-24 are blocked on the deferred half.

Awaiting PL call.

## Test plan

- [ ] CI green on `go test ./test/support/...`
- [ ] Race trace confirmed limited to issue #54 path (not new)
- [ ] PL arbitrates LOC overage