### PR TITLE
fix: D-3+D-20 EventPreProcessor singleton (fixes #19)

### DIFF
--- a/pipeline_stage/pre_processing_stage.go
+++ b/pipeline_stage/pre_processing_stage.go
@@ -1,34 +1,66 @@
+// Package pipelineStage implements the pre-processing stage of the log
+// pipeline. Its sole responsibility is fan-out: each incoming log event is
+// delivered to every registered publishLogMessageHookContract whose level
+// subscription matches. It does not encode, buffer, or persist events.
+//
+// Entry point: EventPreProcessorObj — a package-level singleton initialised
+// once by init. Callers use RegisterHook / DeRegisterHook to manage
+// subscriptions and PreProcess to dispatch an event.
 package pipelineStage
 
 import (
-	"sync"
-
 	"github.com/architagr/lognugget/enum"
 )
 
+// EventPreProcessorObj is the package-level singleton event fan-out observer.
+// It is safe to use after package init completes; callers must not replace or
+// nil this variable.
+//
+// why: assigned directly in init — no sync.Once wrapper needed because init
+// runs exactly once per process; the (&sync.Once{}).Do pattern previously used
+// created a transient Once on every call, providing no actual guard (D-3).
 var EventPreProcessorObj *eventPreProcessorObserver
 
 func init() {
-	(&sync.Once{}).Do(func() {
-		EventPreProcessorObj = newEventPreProcessingObserver()
-	})
+	EventPreProcessorObj = newEventPreProcessingObserver()
 }
 
+// publishLogMessageHookContract is the consumer-side interface for hooks that
+// receive serialised log events. Implementors must be safe to call from a
+// single goroutine; concurrent calls are not made by this package.
+//
+// Name must return a stable, non-empty string that is unique within a given
+// log level — it is used as the map key for RegisterHook / DeRegisterHook.
+// Registering a second hook with the same Name at the same level silently
+// overwrites the first.
 type publishLogMessageHookContract interface {
+	// PublishLogMessage delivers a serialised log event to the hook.
+	// entry must not be retained after the call returns; make a copy if
+	// the hook needs it beyond the call frame.
 	PublishLogMessage(entry []byte)
+	// Name returns the unique identifier for this hook within its level.
 	Name() string
 }
 
+// eventPreProcessorObserver fans out log events to registered hooks keyed by
+// log level.
 type eventPreProcessorObserver struct {
 	hooks map[enum.LogLevel]map[string]publishLogMessageHookContract
 }
 
+// newEventPreProcessingObserver returns a zero-state observer with no hooks.
 func newEventPreProcessingObserver() *eventPreProcessorObserver {
 	return &eventPreProcessorObserver{
 		hooks: make(map[enum.LogLevel]map[string]publishLogMessageHookContract),
 	}
 }
 
+// RegisterHook adds hook to the set of callbacks invoked when PreProcess is
+// called with a matching level. If a hook with the same Name is already
+// registered at level, it is silently overwritten.
+//
+// Hooks registered at enum.LevelUnSet receive every event regardless of the
+// concrete level passed to PreProcess.
 func (e *eventPreProcessorObserver) RegisterHook(level enum.LogLevel, hook publishLogMessageHookContract) {
 	levelHooks, exists := e.hooks[level]
 	if !exists {
@@ -38,6 +70,8 @@ func (e *eventPreProcessorObserver) RegisterHook(level enum.LogLevel, hook publi
 	e.hooks[level] = levelHooks
 }
 
+// DeRegisterHook removes the hook identified by hookName from level. It is a
+// no-op if the level has no registered hooks or hookName is not present.
 func (e *eventPreProcessorObserver) DeRegisterHook(level enum.LogLevel, hookName string) {
 	levelHooks, exists := e.hooks[level]
 	if !exists {
@@ -47,19 +81,26 @@ func (e *eventPreProcessorObserver) DeRegisterHook(level enum.LogLevel, hookName
 	e.hooks[level] = levelHooks
 }
 
+// PreProcess delivers logMsg to all hooks registered at enum.LevelUnSet and
+// then to all hooks registered at the given level.
+//
+// ARCH-11: hook invocation order within a level is undefined (Go map
+// iteration is randomised). Do not rely on any particular delivery order
+// across hooks at the same level.
 func (e *eventPreProcessorObserver) PreProcess(level enum.LogLevel, logMsg []byte) {
 	publish(logMsg, e.hooks[enum.LevelUnSet])
 	publish(logMsg, e.hooks[level])
-
 }
 
-func publish(byteData []byte, hooks map[string]publishLogMessageHookContract /*, wg *sync.WaitGroup*/) {
-	// defer wg.Done()
-	for _, unsetHook := range hooks {
-		unsetHook.PublishLogMessage(byteData)
+// publish calls PublishLogMessage on every hook in the map. Iteration order
+// is undefined — callers must not assume any ordering guarantee.
+func publish(byteData []byte, hooks map[string]publishLogMessageHookContract) {
+	for _, hook := range hooks {
+		hook.PublishLogMessage(byteData)
 	}
 }
 
+// Name returns the observer's stable identifier used by the pipeline registry.
 func (e *eventPreProcessorObserver) Name() string {
 	return "EventPreProcessorObserver"
 }

--- a/pipeline_stage/pre_processing_stage_test.go
+++ b/pipeline_stage/pre_processing_stage_test.go
@@ -1,71 +1,114 @@
+//go:build testing
+
+// Package pipelineStage tests for the event pre-processor observer.
+// Build tag "testing" required because tests import test/support doubles.
 package pipelineStage
 
 import (
 	"testing"
 
 	"github.com/architagr/lognugget/enum"
+	"github.com/architagr/lognugget/test/support"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-type mockUnsetHook struct {
-	isCalled bool
+// hookSet converts a slice of FakePostProcessor records into a set of
+// string payloads for order-independent equality assertions (SC8).
+func hookSet(got [][]byte) map[string]struct{} {
+	s := make(map[string]struct{}, len(got))
+	for _, b := range got {
+		s[string(b)] = struct{}{}
+	}
+	return s
 }
 
-func (e *mockUnsetHook) PublishLogMessage(entry []byte) {
-	e.isCalled = true
-
-}
-func (e *mockUnsetHook) Name() string {
-	return "mockUnsetHook"
-}
-
-type mockDebugHook struct {
-	isCalled bool
-}
-
-func (e *mockDebugHook) PublishLogMessage(entry []byte) {
-	e.isCalled = true
-
-}
-func (e *mockDebugHook) Name() string {
-	return "mockUnsetHook"
-}
-
-func TestPublishMessageNoLevelHookCalled(t *testing.T) {
-	unsetHook := &mockUnsetHook{}
-	debugHook := &mockDebugHook{}
+// Test_PreProcess_UnsetGetsAll verifies that a hook registered at
+// LevelUnSet receives events published for every concrete level.
+func Test_PreProcess_UnsetGetsAll(t *testing.T) {
 	obj := newEventPreProcessingObserver()
-	obj.DeRegisterHook(enum.LevelUnSet, unsetHook.Name())
-	obj.RegisterHook(enum.LevelUnSet, unsetHook)
+	hook := support.NewFakePostProcessor("unset-catch-all")
+	obj.RegisterHook(enum.LevelUnSet, hook)
+
+	levels := []enum.LogLevel{
+		enum.LevelDebug, enum.LevelInfo, enum.LevelWarn, enum.LevelError, enum.LevelFatal,
+	}
+	payloads := [][]byte{
+		[]byte("debug-msg"), []byte("info-msg"), []byte("warn-msg"),
+		[]byte("error-msg"), []byte("fatal-msg"),
+	}
+
+	for i, lvl := range levels {
+		obj.PreProcess(lvl, payloads[i])
+	}
+
+	got := hookSet(hook.Got())
+	for _, p := range payloads {
+		assert.Contains(t, got, string(p),
+			"LevelUnSet hook must receive payload for every level")
+	}
+}
+
+// Test_PreProcess_LevelOnly verifies that a hook registered at
+// LevelDebug only receives Debug-level events and not events for other
+// levels.
+func Test_PreProcess_LevelOnly(t *testing.T) {
+	obj := newEventPreProcessingObserver()
+	debugHook := support.NewFakePostProcessor("debug-only")
 	obj.RegisterHook(enum.LevelDebug, debugHook)
 
-	obj.PreProcess(enum.LevelError, []byte(""))
-	assert.Equal(t, "EventPreProcessorObserver", obj.Name())
-	assert.True(t, unsetHook.isCalled)
-	assert.False(t, debugHook.isCalled)
+	obj.PreProcess(enum.LevelDebug, []byte("debug-payload"))
+	obj.PreProcess(enum.LevelError, []byte("error-payload"))
+	obj.PreProcess(enum.LevelInfo, []byte("info-payload"))
+
+	got := debugHook.Got()
+	require.Len(t, got, 1, "debug hook must receive exactly one event")
+	assert.Equal(t, []byte("debug-payload"), got[0])
 }
 
-func TestPublishMessage(t *testing.T) {
-	unsetHook := &mockUnsetHook{}
-	debugHook := &mockDebugHook{}
+// Test_PreProcess_DeRegister verifies that after DeRegisterHook the
+// removed hook receives no further events.
+func Test_PreProcess_DeRegister(t *testing.T) {
 	obj := newEventPreProcessingObserver()
-	obj.RegisterHook(enum.LevelUnSet, unsetHook)
-	obj.RegisterHook(enum.LevelDebug, debugHook)
+	hook := support.NewFakePostProcessor("removable")
+	obj.RegisterHook(enum.LevelInfo, hook)
 
-	obj.PreProcess(enum.LevelDebug, []byte(""))
+	obj.PreProcess(enum.LevelInfo, []byte("before-remove"))
+	obj.DeRegisterHook(enum.LevelInfo, hook.Name())
+	obj.PreProcess(enum.LevelInfo, []byte("after-remove"))
 
-	assert.True(t, unsetHook.isCalled)
-	assert.True(t, debugHook.isCalled)
+	got := hookSet(hook.Got())
+	assert.Contains(t, got, "before-remove",
+		"hook must have received the pre-deregister event")
+	assert.NotContains(t, got, "after-remove",
+		"deregistered hook must not receive subsequent events")
 }
 
-func TestDeregister(t *testing.T) {
-	unsetHook := &mockUnsetHook{}
-	debugHook := &mockDebugHook{}
+// Test_PreProcess_NameUniqueness verifies that registering a second
+// hook with the same Name() silently overwrites the first (documented
+// behavior: names are unique keys per level).
+func Test_PreProcess_NameUniqueness(t *testing.T) {
 	obj := newEventPreProcessingObserver()
-	obj.RegisterHook(enum.LevelUnSet, unsetHook)
-	obj.RegisterHook(enum.LevelDebug, debugHook)
-	obj.DeRegisterHook(enum.LevelDebug, debugHook.Name())
-	obj.PreProcess(enum.LevelDebug, []byte(""))
-	assert.True(t, unsetHook.isCalled)
-	assert.False(t, debugHook.isCalled)
+
+	first := support.NewFakePostProcessor("shared-name")
+	second := support.NewFakePostProcessor("shared-name")
+
+	obj.RegisterHook(enum.LevelWarn, first)
+	obj.RegisterHook(enum.LevelWarn, second) // overwrites first
+
+	obj.PreProcess(enum.LevelWarn, []byte("warn-payload"))
+
+	assert.Empty(t, first.Got(),
+		"first hook must be overwritten and receive nothing")
+	require.Len(t, second.Got(), 1,
+		"second (overwriting) hook must receive the event")
+	assert.Equal(t, []byte("warn-payload"), second.Got()[0])
+}
+
+// Test_PreProcess_SingletonInit verifies that EventPreProcessorObj is
+// not nil after package init (D-3: the (&sync.Once{}).Do pattern
+// created a transient Once that never guards the assignment).
+func Test_PreProcess_SingletonInit(t *testing.T) {
+	require.NotNil(t, EventPreProcessorObj,
+		"EventPreProcessorObj must be initialised by init()")
 }


### PR DESCRIPTION
## Summary

- **D-3**: Replaced `(&sync.Once{}).Do(...)` in `init()` with a direct assignment. The transient `sync.Once` provided no actual guard because `init()` runs exactly once per process — it was dead code that obscured the intent.
- **D-20**: Added `ARCH-11` doc comment to `PreProcess` and `publish` documenting that hook invocation order within a level is undefined (Go map iteration is randomised).
- **Test rewrite (TS-19)**: Replaced `mockUnsetHook`/`mockDebugHook` types (T-5: both returned `"mockUnsetHook"` as `Name()`) with `support.FakePostProcessor` doubles with distinct names. Removed the spurious `DeRegisterHook` before `RegisterHook` (T-6). All assertions use set-equality (`hookSet`) instead of ordered comparison (SC8).

## Test plan

- [x] `Test_PreProcess_UnsetGetsAll` — LevelUnSet hook receives events for all levels
- [x] `Test_PreProcess_LevelOnly` — LevelDebug hook receives only Debug events
- [x] `Test_PreProcess_DeRegister` — DeRegisterHook stops future delivery
- [x] `Test_PreProcess_NameUniqueness` — same Name() overwrites prior hook
- [x] `Test_PreProcess_SingletonInit` — EventPreProcessorObj not nil after init
- [x] `go test -tags testing ./pipeline_stage/...` — all green
- [x] `golangci-lint run --new-from-rev HEAD ./pipeline_stage/...` — clean
- [x] `go doc ./pipeline_stage/` — package and exported identifiers render correctly
- [x] `entry/` failures are pre-existing D-1, not introduced by this PR

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)