### PR TITLE
fix: D-4 RFC3339 default + AppendFormat zero-alloc

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ var (
 	DafaultEncoderType enum.LogEncodeType = enum.EncoderJSON // Default encoder type
 	DafaultAddSource   bool               = true             // Default to add source information
 	DefaultOutput      io.Writer          = os.Stdout        // Default output writer
-	DefaultTimeFormat  string             = time.RFC822      // Default time format for log entries
+	DefaultTimeFormat  string             = time.RFC3339     // Default time format for log entries
 	DafaultLogBuffer   int                = 20               // Default buffer size for logs
 	DefaultPrefix      string             = "custom."
 )

--- a/custom_time/time.go
+++ b/custom_time/time.go
@@ -1,11 +1,32 @@
+// Package customTime provides time utilities for LogNugget log formatting.
+// It exposes Now (UTC clock), Format (string return, kept for compatibility),
+// and AppendFormat (zero-alloc, preferred on hot paths). It does not own any
+// configuration state — callers pass the layout string explicitly.
 package customTime
 
 import "time"
 
+// TimeNow returns the current time in UTC. Using UTC ensures log timestamps
+// are timezone-neutral and comparable across services.
 func TimeNow() time.Time {
 	return time.Now().UTC()
 }
 
+// Format formats t using layout and returns the result as a new string.
+// Prefer AppendFormat on hot paths to avoid the string allocation.
 func Format(t time.Time, format string) string {
 	return t.Format(format)
+}
+
+// AppendFormat appends the textual representation of t, formatted according
+// to layout, to dst and returns the extended buffer. It performs zero heap
+// allocations when dst has sufficient capacity, making it safe for the hot
+// log-formatting path.
+//
+// why: time.Time.AppendFormat writes directly into the provided byte slice,
+// avoiding the string allocation that time.Time.Format incurs on every call.
+// On the hot path this saves ~1 alloc / ~30 ns per log entry (see story 037
+// bench results).
+func AppendFormat(dst []byte, t time.Time, layout string) []byte {
+	return t.AppendFormat(dst, layout)
 }

--- a/custom_time/time_test.go
+++ b/custom_time/time_test.go
@@ -1,0 +1,48 @@
+// Package customTime provides time utilities for LogNugget log formatting.
+package customTime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+)
+
+// Test_TimeNow_UTC verifies that Now() always returns a time value in
+// the UTC location, regardless of the local system timezone.
+func Test_TimeNow_UTC(t *testing.T) {
+	t.Parallel()
+
+	got := TimeNow()
+	if got.Location() != time.UTC {
+		t.Errorf("TimeNow() location = %v, want UTC", got.Location())
+	}
+}
+
+// Test_AppendFormat_NoAlloc verifies that AppendFormat performs zero heap
+// allocations per call, which is the key property that makes it safe for
+// the hot log-formatting path.
+func Test_AppendFormat_NoAlloc(t *testing.T) {
+	t.Parallel()
+
+	dst := make([]byte, 0, 64)
+	fixed := time.Date(2024, 1, 2, 15, 4, 5, 0, time.UTC)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		dst = AppendFormat(dst[:0], fixed, time.RFC3339)
+	})
+
+	if allocs != 0 {
+		t.Errorf("AppendFormat allocs = %v, want 0", allocs)
+	}
+}
+
+// Test_DefaultTimeFormat_RFC3339 verifies that the package-level default
+// time format constant is set to time.RFC3339, not RFC3339Nano or RFC822.
+func Test_DefaultTimeFormat_RFC3339(t *testing.T) {
+	t.Parallel()
+
+	if config.DefaultTimeFormat != time.RFC3339 {
+		t.Errorf("config.DefaultTimeFormat = %q, want %q (time.RFC3339)", config.DefaultTimeFormat, time.RFC3339)
+	}
+}


### PR DESCRIPTION
Fixes #23

refs #12

## Changes
- `config/config.go`: `DefaultTimeFormat = time.RFC3339` (was `time.RFC822`)
- `custom_time/time.go`: add `AppendFormat(dst []byte, t time.Time, layout string) []byte` — zero-alloc via `t.AppendFormat`
- `custom_time/time_test.go`: TS-23 — `Test_TimeNow_UTC`, `Test_AppendFormat_NoAlloc`, `Test_DefaultTimeFormat_RFC3339`

## Gate
- All 3 tests green
- golangci-lint clean
- bench-check PASS (~1870–2077 ns/op, well within 5 ms threshold)