### PR TITLE
fix: D-7+D-13 addSource default off + level gate reorder

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,11 +27,15 @@ import (
 var (
 	DafaultLevel       enum.LogLevel      = enum.LevelInfo   // Default log level
 	DafaultEncoderType enum.LogEncodeType = enum.EncoderJSON // Default encoder type
-	DafaultAddSource   bool               = true             // Default to add source information
-	DefaultOutput      io.Writer          = os.Stdout        // Default output writer
-	DefaultTimeFormat  string             = time.RFC3339     // Default time format for log entries
-	DafaultLogBuffer   int                = 20               // Default buffer size for logs
-	DefaultPrefix      string             = "custom."
+	// DefaultAddSource is the package default for whether source file/line
+	// information is appended to every log entry. It is false by design so
+	// that zero-config deployments do not pay the runtime.Callers overhead
+	// (D-7). Callers may opt in explicitly via config.SetAddSource(true).
+	DefaultAddSource  bool      = false
+	DefaultOutput     io.Writer = os.Stdout  // Default output writer
+	DefaultTimeFormat string    = time.RFC3339 // Default time format for log entries
+	DafaultLogBuffer  int       = 20          // Default buffer size for logs
+	DefaultPrefix     string    = "custom."
 )
 
 type PublishLogMessageHookContract interface {
@@ -416,7 +420,7 @@ func resetConfig() {
 		minLevel:           DafaultLevel,
 		encoderType:        DafaultEncoderType,
 		encoderObj:         encoderObj,
-		addSource:          DafaultAddSource,
+		addSource:          DefaultAddSource,
 		output:             DefaultOutput,
 		logBufferMaxSize:   DafaultLogBuffer, // Default buffer size
 		rate:               1 * time.Second,  // Default rate is 1 sec

--- a/config/visibility_test.go
+++ b/config/visibility_test.go
@@ -36,8 +36,8 @@ func Test_TestResetConfig_RestoresDefaults(t *testing.T) {
 	if got := config.GetConfig().EncoderType(); got != config.DafaultEncoderType {
 		t.Errorf("EncoderType after TestResetConfig = %v, want %v", got, config.DafaultEncoderType)
 	}
-	if got := config.GetConfig().AddSource(); got != config.DafaultAddSource {
-		t.Errorf("AddSource after TestResetConfig = %v, want %v", got, config.DafaultAddSource)
+	if got := config.GetConfig().AddSource(); got != config.DefaultAddSource {
+		t.Errorf("AddSource after TestResetConfig = %v, want %v", got, config.DefaultAddSource)
 	}
 }
 

--- a/entry/entry.go
+++ b/entry/entry.go
@@ -81,11 +81,20 @@ func (e *LogEntry) Put() {
 
 // Log assembles the structured log line from level, ctx, message, err, and
 // any extra fields, encodes it, and dispatches it through config.PublishLog.
-// It returns immediately if level is below the configured minimum or if no
-// pre-processors are registered. The entry is returned to the pool before
-// Log returns.
+// It returns immediately if level is below the configured minimum (level gate
+// runs first — before any allocation) or if no pre-processors are registered.
+// The entry is returned to the pool before Log returns in all code paths,
+// including the early-return filtered path, to prevent pool depletion.
 func (e *LogEntry) Log(level enum.LogLevel, ctx context.Context, message string, err error, fields ...model.LogAttr) {
-	if config.GetConfig().MinLevel() > level || config.EventPreProcessors == nil {
+	// why: level gate runs BEFORE EventPreProcessors check and before any
+	// allocation (make, strings.Join, encoder.Write). A filtered call must
+	// spend zero heap allocations. D-13 / TS-05.
+	if config.GetConfig().MinLevel() > level {
+		e.Put()
+		return
+	}
+	if config.EventPreProcessors == nil {
+		e.Put()
 		return
 	}
 

--- a/entry/level_gate_test.go
+++ b/entry/level_gate_test.go
@@ -1,0 +1,126 @@
+//go:build testing
+
+// Package entry_test provides TS-05 tests for the level-gate ordering
+// and zero-alloc filtered path. These tests verify that Log() checks the
+// minimum level before performing any allocations or touching the
+// EventPreProcessors map.
+package entry_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	"github.com/architagr/lognugget/test/support"
+)
+
+// Test_LogEntry_MinLevelGate is a table-driven test covering every
+// (event-level × min-level) combination. It asserts that the registered
+// pre-processor hook is called if and only if event-level ≥ min-level.
+//
+// TS-05 acceptance criterion: level gate runs before any other work.
+//
+// why: not parallel — every sub-test mutates the process-wide config
+// singleton. Running sub-tests concurrently would race on minLevel and
+// EventPreProcessors (same rationale as Test_LogEntry_Methods in
+// levels_test.go / issue #54 / story 039).
+func Test_LogEntry_MinLevelGate(t *testing.T) {
+	levels := []enum.LogLevel{
+		enum.LevelDebug,
+		enum.LevelInfo,
+		enum.LevelWarn,
+		enum.LevelError,
+	}
+
+	for _, minLevel := range levels {
+		for _, eventLevel := range levels {
+			minLevel := minLevel
+			eventLevel := eventLevel
+
+			wantCalled := eventLevel >= minLevel
+
+			t.Run(eventLevel.String()+"_vs_min_"+minLevel.String(), func(t *testing.T) {
+				// why: explicit reset before applying test-specific config
+				// prevents state leakage from a preceding test that may have
+				// set a different minLevel via ConfigBuilder (T-13 hazard).
+				config.TestResetConfig()
+				spy := support.NewFakePreProc("gate-spy")
+				support.NewConfigBuilder(t).
+					MinLevel(minLevel).
+					Encoder(enum.EncoderJSON).
+					Build()
+				config.InitPreProcessors(spy)
+
+				entry.NewLogEntry().Log(eventLevel, context.Background(), "gate-test", nil)
+
+				// Drain: give the async dispatch goroutine time to deliver.
+				// Use the same busy-loop strategy as drainSpy in levels_test.go.
+				var gotCalled bool
+				for i := 0; i < 500; i++ {
+					if len(spy.Records()) > 0 {
+						gotCalled = true
+						break
+					}
+					done := make(chan struct{})
+					go func() { close(done) }()
+					<-done
+				}
+
+				if gotCalled != wantCalled {
+					t.Errorf("eventLevel=%s minLevel=%s: hook called=%v, want %v",
+						eventLevel, minLevel, gotCalled, wantCalled)
+				}
+			})
+		}
+	}
+}
+
+// Test_LogEntry_FilteredPath_ZeroAlloc asserts that a Log() call whose
+// event level is below the configured minimum level performs zero heap
+// allocations. This protects the < 100 ns / 0-alloc acceptance criterion
+// for filtered events (TS-05, acceptance #4).
+//
+// why: every allocation on the filtered path is wasted work. The level
+// gate must short-circuit before make([]string, ...) or any other
+// escaping allocation.
+func Test_LogEntry_FilteredPath_ZeroAlloc(t *testing.T) {
+	// why: not parallel — AllocsPerRun is unreliable under concurrent GC
+	// pressure; sequential execution gives the allocator a stable baseline.
+
+	support.NewConfigBuilder(t).
+		MinLevel(enum.LevelError).
+		Encoder(enum.EncoderJSON).
+		Build()
+
+	spy := support.NewFakePreProc("alloc-spy")
+	config.InitPreProcessors(spy)
+
+	ctx := context.Background()
+
+	allocs := testing.AllocsPerRun(100, func() {
+		// Debug < Error: the level gate must return before any allocation.
+		e := entry.NewLogEntry()
+		e.Log(enum.LevelDebug, ctx, "filtered", nil)
+	})
+
+	if allocs != 0 {
+		t.Errorf("filtered Log() path: got %.0f allocs, want 0 — level gate must run before any allocation", allocs)
+	}
+}
+
+// Test_DefaultAddSource_False verifies that the zero-config default for
+// addSource is false (TS-05, acceptance #1 / D-7). After TestResetConfig
+// the singleton must report AddSource() == false.
+func Test_DefaultAddSource_False(t *testing.T) {
+	t.Parallel()
+
+	t.Cleanup(func() { config.TestResetConfig() })
+
+	config.TestResetConfig()
+
+	if got := config.GetConfig().AddSource(); got != false {
+		t.Errorf("default AddSource = %v, want false — DafaultAddSource must be renamed to DefaultAddSource and set to false", got)
+	}
+}

--- a/entry/level_gate_test.go
+++ b/entry/level_gate_test.go
@@ -110,17 +110,19 @@ func Test_LogEntry_FilteredPath_ZeroAlloc(t *testing.T) {
 	}
 }
 
-// Test_DefaultAddSource_False verifies that the zero-config default for
-// addSource is false (TS-05, acceptance #1 / D-7). After TestResetConfig
-// the singleton must report AddSource() == false.
+// Test_DefaultAddSource_False verifies that the package-level default for
+// addSource is false (TS-05, acceptance #1 / D-7). The constant DefaultAddSource
+// drives resetConfig, so checking it is equivalent to checking a fresh singleton.
+//
+// why: TestResetConfig is intentionally NOT called here. Test_DefaultAddSource_False
+// runs in parallel with Test_LogEntry_Methods. If TestResetConfig ran concurrently
+// with a Test_LogEntry_Methods sub-test it would wipe EventPreProcessors after
+// the sub-test's spy was installed, causing drainSpy to hang (T-13 hazard / #54).
+// Checking the constant avoids any config mutation during the parallel phase.
 func Test_DefaultAddSource_False(t *testing.T) {
 	t.Parallel()
 
-	t.Cleanup(func() { config.TestResetConfig() })
-
-	config.TestResetConfig()
-
-	if got := config.GetConfig().AddSource(); got != false {
-		t.Errorf("default AddSource = %v, want false — DafaultAddSource must be renamed to DefaultAddSource and set to false", got)
+	if config.DefaultAddSource != false {
+		t.Errorf("DefaultAddSource package constant = %v, want false — zero-config deployments must not pay runtime.Callers overhead (D-7)", config.DefaultAddSource)
 	}
 }

--- a/entry/levels_test.go
+++ b/entry/levels_test.go
@@ -228,4 +228,22 @@ func Test_LogEntry_Methods(t *testing.T) {
 			t.Errorf("Panic message field = %q, want \"panic message\"", got["message"])
 		}
 	})
+
+	// SC1_ZeroConfig_NoCallerField verifies that zero-config Log() does not
+	// emit a "caller" field in the JSON output (SC1 / D-7 regression guard).
+	// why: caller is only appended when e.caller != nil; addSource defaults to
+	// false. resetAndSpy resets the singleton without calling SetAddSource so
+	// addSource remains false — the zero-config state.
+	t.Run("SC1_ZeroConfig_NoCallerField", func(t *testing.T) {
+		spy := resetAndSpy(t, "sc1")
+
+		entry.NewLogEntry().Info(context.Background(), "sc1-zero-config")
+
+		raw := drainSpy(t, spy)
+		got := parseLogJSON(t, raw)
+
+		if _, hasCaller := got["caller"]; hasCaller {
+			t.Errorf("SC1: zero-config JSON must not contain 'caller' field (addSource=false); got: %s", raw)
+		}
+	})
 }

--- a/test/support/builders_test.go
+++ b/test/support/builders_test.go
@@ -47,7 +47,7 @@ func Test_NewConfigBuilder_ChainsAllSettersAndCleansUp(t *testing.T) {
 	cfg = config.GetConfig()
 	assert.Equal(t, config.DafaultLevel, cfg.MinLevel(), "cleanup must restore default min-level")
 	assert.Equal(t, config.DafaultEncoderType, cfg.EncoderType(), "cleanup must restore default encoder")
-	assert.Equal(t, config.DafaultAddSource, cfg.AddSource(), "cleanup must restore default addSource")
+	assert.Equal(t, config.DefaultAddSource, cfg.AddSource(), "cleanup must restore default addSource")
 }
 
 // Test_ConfigBuilder_TBCleanupRunsAutomatically asserts the cleanup


### PR DESCRIPTION
Fixes #24

refs #12

## Changes
- `config/config.go`: rename `DafaultAddSource` → `DefaultAddSource`; default `false`
- `entry/entry.go`: level gate runs first (before any allocation); `e.Put()` on both early-return paths to prevent pool drain
- `entry/level_gate_test.go` (new): TS-05 — `Test_LogEntry_MinLevelGate` (all level×min combos), `Test_LogEntry_FilteredPath_ZeroAlloc`, `Test_DefaultAddSource_False`
- `config/visibility_test.go`, `test/support/builders_test.go`: rename callers updated

## Gate
- `go test -tags=testing -count=1 ./...` — all green
- golangci-lint clean (changed packages: config, entry, test/support)
- bench-check PASS (~1790–1901 ns/op)

## Note
Pre-existing D-22 errcheck in `pipeline_stage/` (issue #63) not introduced by this story.