### PR TITLE
feat: ARCH-2 encoder iface Append + newline framing (#27)

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -1,3 +1,9 @@
+// Package encoder provides the Encoder interface and its implementations for
+// formatting structured log entries. Each encoder is responsible for wrapping
+// the pre-rendered body bytes and appending a trailing newline (ARCH-14) so
+// callers never need to frame output themselves. The package exposes
+// DefaultEncoderFactory as the primary entry point; direct construction via
+// NewJSONEncoder and NewTextEncoder is available for testing and advanced use.
 package encoder
 
 import (
@@ -6,12 +12,28 @@ import (
 	"github.com/architagr/lognugget/enum"
 )
 
+// ErrUnsupportedEncoderType is returned by DefaultEncoderFactory when the
+// requested LogEncodeType is not recognised. Callers should use errors.Is to
+// detect it and fall back to a default encoder or abort initialisation.
 var ErrUnsupportedEncoderType = errors.New("unsupported encoder type")
 
+// Encoder formats a pre-rendered log body and appends it to dst.
+//
+// Append appends the formatted representation of body to dst and returns the
+// extended slice. If dst is nil the implementation allocates a new slice.
+// Implementations MUST append a trailing newline (ARCH-14) so callers do not
+// need to frame output. Append is safe for concurrent use on a single Encoder
+// value; it must not retain references to dst or body after returning.
+//
+// Name returns a stable, non-empty identifier for the encoder (e.g. "json",
+// "text") suitable for logging and metrics labels.
 type Encoder interface {
-	Write(string) ([]byte, error)
+	Append(dst, body []byte) []byte
+	Name() string
 }
 
+// DefaultEncoderFactory returns the Encoder for the given LogEncodeType.
+// It returns ErrUnsupportedEncoderType for any type not explicitly handled.
 func DefaultEncoderFactory(encoderType enum.LogEncodeType) (Encoder, error) {
 	switch encoderType {
 	case enum.EncoderJSON:

--- a/encoder/factory_test.go
+++ b/encoder/factory_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Test_DefaultEncoderFactory_KnownTypes covers TS-15: JSON and Text
-// resolve to non-nil encoders that honor the F7 Write contract.
+// resolve to non-nil encoders that honor the Append contract.
 func Test_DefaultEncoderFactory_KnownTypes(t *testing.T) {
 	t.Parallel()
 
@@ -17,8 +17,8 @@ func Test_DefaultEncoderFactory_KnownTypes(t *testing.T) {
 		in   enum.LogEncodeType
 		want string
 	}{
-		{"json wraps", enum.EncoderJSON, "{a:1}"},
-		{"text passthrough", enum.EncoderText, "a:1"},
+		{"json wraps", enum.EncoderJSON, "{a:1}\n"},
+		{"text passthrough", enum.EncoderText, "a:1\n"},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -31,10 +31,7 @@ func Test_DefaultEncoderFactory_KnownTypes(t *testing.T) {
 			if enc == nil {
 				t.Fatal("factory returned nil encoder")
 			}
-			out, err := enc.Write("a:1")
-			if err != nil {
-				t.Fatalf("write err: %v", err)
-			}
+			out := enc.Append(nil, []byte("a:1"))
 			if string(out) != tc.want {
 				t.Fatalf("got %q want %q", string(out), tc.want)
 			}

--- a/encoder/json_encoder.go
+++ b/encoder/json_encoder.go
@@ -1,19 +1,33 @@
 package encoder
 
-// NewJSONEncoder returns a JSON encoder that satisfies the F7 Write contract.
-// why: D-17 removed the unused *json.Encoder field; struct is now empty so
-// allocation cost on the hot path is zero.
+// compile-time proof that JSONEncoder satisfies the Encoder interface.
+var _ Encoder = (*JSONEncoder)(nil)
+
+// JSONEncoder wraps a pre-rendered log body in JSON object braces and appends
+// a trailing newline. It holds no state; all methods are safe for concurrent
+// use.
+type JSONEncoder struct{}
+
+// NewJSONEncoder returns a new JSONEncoder that satisfies the Encoder
+// interface.
 func NewJSONEncoder() Encoder {
 	return &JSONEncoder{}
 }
 
-// JSONEncoder wraps an entry's pre-formatted body in JSON object braces.
-// It holds no state; methods are safe for concurrent use.
-type JSONEncoder struct{}
+// Append wraps body as `{<body>}\n` and appends the result to dst.
+// dst may be nil; a new slice is allocated in that case.
+//
+// why: braces are prepended/appended inline rather than via fmt.Sprintf to
+// avoid an extra allocation on the hot path (F10 field escaping arrives in
+// story 016 — only framing is handled here).
+func (e *JSONEncoder) Append(dst, body []byte) []byte {
+	dst = append(dst, '{')
+	dst = append(dst, body...)
+	dst = append(dst, '}', '\n')
+	return dst
+}
 
-// Write returns entryData wrapped in "{...}". The F7 contract guarantees a
-// nil error for the in-process path; the signature retains error for ARCH-2
-// (story 015) when sinks may surface I/O failures.
-func (e *JSONEncoder) Write(entryData string) ([]byte, error) {
-	return []byte("{" + entryData + "}"), nil
+// Name returns "json", the stable identifier for this encoder.
+func (e *JSONEncoder) Name() string {
+	return "json"
 }

--- a/encoder/json_encoder_bench_test.go
+++ b/encoder/json_encoder_bench_test.go
@@ -1,0 +1,19 @@
+package encoder
+
+import "testing"
+
+// Benchmark_JSONEncoder_Append measures the hot-path cost of wrapping a
+// pre-rendered log body in JSON braces and appending a newline. Input shape:
+// a 64-byte body representative of a single-line structured log event. Budget:
+// the encoder step must stay well under the 5 ms gate; expected ~10–20 ns/op
+// with zero allocations when dst is pre-allocated.
+func Benchmark_JSONEncoder_Append(b *testing.B) {
+	b.ReportAllocs()
+	enc := NewJSONEncoder()
+	body := []byte(`"time":"2026-01-02T03:04:05Z","level":"info","msg":"ok"`)
+	buf := make([]byte, 0, 128)
+	for i := 0; i < b.N; i++ {
+		buf = enc.Append(buf[:0], body)
+	}
+	_ = buf
+}

--- a/encoder/json_encoder_test.go
+++ b/encoder/json_encoder_test.go
@@ -23,17 +23,14 @@ func Test_JSONEncoder_NoEmbeddedNilEncoder(t *testing.T) {
 	}
 }
 
-// Test_JSONEncoder_Write_WrapsInBraces locks the externally observable
-// behavior: F7 contract Write(string) ([]byte, error) returns "{<in>}".
-func Test_JSONEncoder_Write_WrapsInBraces(t *testing.T) {
+// Test_JSONEncoder_Append_WrapsInBraces locks the externally observable
+// behavior: Append returns `{<in>}\n`.
+func Test_JSONEncoder_Append_WrapsInBraces(t *testing.T) {
 	t.Parallel()
 
 	enc := NewJSONEncoder()
-	got, err := enc.Write("key:value")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if string(got) != "{key:value}" {
-		t.Fatalf("got %q, want %q", string(got), "{key:value}")
+	got := enc.Append(nil, []byte("key:value"))
+	if string(got) != "{key:value}\n" {
+		t.Fatalf("got %q, want %q", string(got), "{key:value}\n")
 	}
 }

--- a/encoder/text_encoder.go
+++ b/encoder/text_encoder.go
@@ -1,13 +1,28 @@
 package encoder
 
+// compile-time proof that TextEncoder satisfies the Encoder interface.
+var _ Encoder = (*TextEncoder)(nil)
+
+// TextEncoder passes the pre-rendered log body through unchanged and appends a
+// trailing newline (ARCH-14). It holds no state; all methods are safe for
+// concurrent use.
+type TextEncoder struct{}
+
+// NewTextEncoder returns a new TextEncoder that satisfies the Encoder
+// interface.
 func NewTextEncoder() Encoder {
-	// Implementation of Text encoder
 	return &TextEncoder{}
 }
 
-type TextEncoder struct{}
+// Append appends body followed by a newline to dst and returns the result.
+// dst may be nil; a new slice is allocated in that case.
+func (e *TextEncoder) Append(dst, body []byte) []byte {
+	dst = append(dst, body...)
+	dst = append(dst, '\n')
+	return dst
+}
 
-func (e *TextEncoder) Write(entryData string) ([]byte, error) {
-	// Implementation of Text encoding logic
-	return []byte(entryData), nil
+// Name returns "text", the stable identifier for this encoder.
+func (e *TextEncoder) Name() string {
+	return "text"
 }

--- a/encoder/text_encoder_test.go
+++ b/encoder/text_encoder_test.go
@@ -1,0 +1,60 @@
+//go:build testing
+
+package encoder
+
+import (
+	"testing"
+)
+
+// Test_Encoder_Iface_Compliance verifies that both JSONEncoder and TextEncoder
+// satisfy the Encoder interface at compile time (via the var _ checks at the
+// bottom of their respective files) and that Name() returns a non-empty string
+// for each.
+func Test_Encoder_Iface_Compliance(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		enc  Encoder
+	}{
+		{"JSONEncoder", NewJSONEncoder()},
+		{"TextEncoder", NewTextEncoder()},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.enc.Name(); got == "" {
+				t.Fatalf("%s.Name() returned empty string", tc.name)
+			}
+		})
+	}
+}
+
+// Test_TextEncoder_Append_AddsNewline verifies that TextEncoder.Append returns
+// body with a trailing newline appended to dst — ARCH-14 newline-framing
+// contract.
+func Test_TextEncoder_Append_AddsNewline(t *testing.T) {
+	t.Parallel()
+
+	enc := NewTextEncoder()
+	got := enc.Append(nil, []byte("hello"))
+	want := "hello\n"
+	if string(got) != want {
+		t.Fatalf("got %q, want %q", string(got), want)
+	}
+}
+
+// Test_JSONEncoder_Append_WrapsAndNewline verifies that JSONEncoder.Append
+// wraps body in JSON object braces and appends a newline — ARCH-14
+// newline-framing contract.
+func Test_JSONEncoder_Append_WrapsAndNewline(t *testing.T) {
+	t.Parallel()
+
+	enc := NewJSONEncoder()
+	got := enc.Append(nil, []byte(`"key":"val"`))
+	want := "{\"key\":\"val\"}\n"
+	if string(got) != want {
+		t.Fatalf("got %q, want %q", string(got), want)
+	}
+}

--- a/entry/entry.go
+++ b/entry/entry.go
@@ -87,7 +87,7 @@ func (e *LogEntry) Put() {
 // including the early-return filtered path, to prevent pool depletion.
 func (e *LogEntry) Log(level enum.LogLevel, ctx context.Context, message string, err error, fields ...model.LogAttr) {
 	// why: level gate runs BEFORE EventPreProcessors check and before any
-	// allocation (make, strings.Join, encoder.Write). A filtered call must
+	// allocation (make, strings.Join, encoder.Append). A filtered call must
 	// spend zero heap allocations. D-13 / TS-05.
 	if config.GetConfig().MinLevel() > level {
 		e.Put()
@@ -129,7 +129,7 @@ func (e *LogEntry) Log(level enum.LogLevel, ctx context.Context, message string,
 	}
 
 	en := config.GetConfig().Encoder()
-	byteData, _ := en.Write(str)
+	byteData := en.Append(nil, []byte(str))
 	config.PublishLog(level, byteData)
 
 	e.Put()

--- a/test/support/doubles.go
+++ b/test/support/doubles.go
@@ -151,9 +151,9 @@ func (s *StubStaticParser) Evaluations() int {
 	return s.evaluations
 }
 
-// StubEncoder implements encoder.Encoder with a passthrough Write that
-// returns the body verbatim and records every call. Isolates pipeline
-// tests from real-encoder churn (F10).
+// StubEncoder implements encoder.Encoder with a passthrough Append that
+// appends body verbatim (plus newline) and records every call body. Isolates
+// pipeline tests from real-encoder churn (F10).
 type StubEncoder struct {
 	mu    sync.Mutex
 	calls []string
@@ -162,15 +162,20 @@ type StubEncoder struct {
 // NewStubEncoder returns a zero-state StubEncoder.
 func NewStubEncoder() *StubEncoder { return &StubEncoder{} }
 
-// Write records body and returns it as raw bytes; never errors.
-func (s *StubEncoder) Write(body string) ([]byte, error) {
+// Append records body as a string, appends body+newline to dst, and returns
+// the extended slice.
+func (s *StubEncoder) Append(dst, body []byte) []byte {
 	s.mu.Lock()
-	s.calls = append(s.calls, body)
+	s.calls = append(s.calls, string(body))
 	s.mu.Unlock()
-	return []byte(body), nil
+	dst = append(dst, body...)
+	return append(dst, '\n')
 }
 
-// Calls returns the recorded Write inputs in call order.
+// Name returns "stub".
+func (s *StubEncoder) Name() string { return "stub" }
+
+// Calls returns the recorded Append body inputs in call order.
 func (s *StubEncoder) Calls() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/test/support/doubles_test.go
+++ b/test/support/doubles_test.go
@@ -85,15 +85,15 @@ func Test_StubStaticParser_EvaluatesOnce(t *testing.T) {
 	assert.Equal(t, 1, stub.Evaluations(), "F15: static parser must be evaluated once")
 }
 
-// Test_StubEncoder_WritePassthrough covers acceptance #5.
-func Test_StubEncoder_WritePassthrough(t *testing.T) {
+// Test_StubEncoder_AppendPassthrough covers acceptance #5: Append records
+// the body and returns body+newline appended to dst.
+func Test_StubEncoder_AppendPassthrough(t *testing.T) {
 	t.Parallel()
 	enc := support.NewStubEncoder()
-	out, err := enc.Write("hello")
-	require.NoError(t, err)
-	assert.Equal(t, []byte("hello"), out)
+	out := enc.Append(nil, []byte("hello"))
+	assert.Equal(t, []byte("hello\n"), out)
 
-	_, _ = enc.Write("world")
+	enc.Append(nil, []byte("world"))
 	assert.Equal(t, []string{"hello", "world"}, enc.Calls())
 }
 


### PR DESCRIPTION
Fixes #27

## What changed

- **`encoder/encoder.go`**: replaced `Write(string)([]byte,error)` with `Append(dst,body []byte)[]byte` + `Name() string` on the `Encoder` interface. Old `Write` shim removed entirely (ARCH-2).
- **`encoder/json_encoder.go`**: implements `Append` — appends `{body}\n` to dst; zero allocation when dst has capacity. Compile-time check `var _ Encoder = (*JSONEncoder)(nil)` added.
- **`encoder/text_encoder.go`**: implements `Append` — appends `body\n` to dst. Compile-time check added.
- **`encoder/factory.go`**: no signature change; continues returning `Encoder` interface.
- **`entry/entry.go`**: `Log` calls `en.Append(nil, []byte(str))` instead of `en.Write(str)`.
- **`test/support/doubles.go`**: `StubEncoder` updated to `Append`/`Name` — no more `Write`.
- **`encoder/text_encoder_test.go`** (new, `//go:build testing`): TS-18 tests — iface compliance, TextEncoder newline, JSONEncoder wraps+newline.
- **`encoder/json_encoder_bench_test.go`** (new): `Benchmark_JSONEncoder_Append` — ~2 ns/op, 0 allocs.

## Acceptance criteria met

1. `Write(string)([]byte,error)` fully removed — no shim.
2. Newline framing centralised in encoders (ARCH-14) — callers do not append `\n`.
3. SC1 still green: output ends `\n`.
4. Caller passes pre-rendered body bytes; encoder appends to dst.
5. Compile-time interface checks on both encoder types.

## Test results

```
ok  github.com/architagr/lognugget/encoder   (3x race)
ok  github.com/architagr/lognugget/entry     (3x race)
ok  all packages                              (full suite)
bench: Benchmark_JSONEncoder_Append ~2.2 ns/op, 0 allocs
bench-check: PASS
golangci-lint: clean
```