### PR TITLE
feat: D-10 graceful DefaultEncoderFactory + DefaultEncoderFactoryE

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -146,10 +146,10 @@ func SetEncoderType(encoderType enum.LogEncodeType) {
 	configMu.Lock()
 	defer configMu.Unlock()
 
-	defaultConfig.encoderObj, err = encoder.DefaultEncoderFactory(encoderType)
+	defaultConfig.encoderObj, err = encoder.DefaultEncoderFactoryE(encoderType)
 	if err != nil {
 		encoderType = enum.EncoderJSON
-		defaultConfig.encoderObj, _ = encoder.DefaultEncoderFactory(encoderType)
+		defaultConfig.encoderObj = encoder.DefaultEncoderFactory(encoderType)
 	}
 
 	defaultConfig.encoderType = encoderType
@@ -415,7 +415,7 @@ func resetConfig() {
 	// Build the new config and channel before acquiring the lock to
 	// minimise lock-hold time — encoder factory can take allocations.
 	newCh := make(chan LogEvent, 10)
-	encoderObj, _ := encoder.DefaultEncoderFactory(enum.EncoderJSON)
+	encoderObj := encoder.DefaultEncoderFactory(enum.EncoderJSON)
 	newCfg := &Config{
 		minLevel:           DafaultLevel,
 		encoderType:        DafaultEncoderType,

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -12,10 +12,9 @@ import (
 	"github.com/architagr/lognugget/enum"
 )
 
-// ErrUnsupportedEncoderType is returned by DefaultEncoderFactory when the
-// requested LogEncodeType is not recognised. Callers should use errors.Is to
-// detect it and fall back to a default encoder or abort initialisation.
-var ErrUnsupportedEncoderType = errors.New("unsupported encoder type")
+// ErrUnknownEncoder is returned by DefaultEncoderFactoryE when the requested
+// LogEncodeType is not recognised. Callers should use errors.Is to detect it.
+var ErrUnknownEncoder = errors.New("unknown encoder type")
 
 // Encoder formats a pre-rendered log body and appends it to dst.
 //
@@ -33,14 +32,25 @@ type Encoder interface {
 }
 
 // DefaultEncoderFactory returns the Encoder for the given LogEncodeType.
-// It returns ErrUnsupportedEncoderType for any type not explicitly handled.
-func DefaultEncoderFactory(encoderType enum.LogEncodeType) (Encoder, error) {
+// For unknown types it falls back to the JSON encoder.
+// Use DefaultEncoderFactoryE to surface an error instead.
+func DefaultEncoderFactory(encoderType enum.LogEncodeType) Encoder {
+	enc, err := DefaultEncoderFactoryE(encoderType)
+	if err != nil {
+		enc, _ = DefaultEncoderFactoryE(enum.EncoderJSON)
+	}
+	return enc
+}
+
+// DefaultEncoderFactoryE returns the Encoder for the given LogEncodeType.
+// It returns ErrUnknownEncoder for any type not explicitly handled.
+func DefaultEncoderFactoryE(encoderType enum.LogEncodeType) (Encoder, error) {
 	switch encoderType {
 	case enum.EncoderJSON:
 		return NewJSONEncoder(), nil
 	case enum.EncoderText:
 		return NewTextEncoder(), nil
 	default:
-		return nil, ErrUnsupportedEncoderType
+		return nil, ErrUnknownEncoder
 	}
 }

--- a/encoder/factory_test.go
+++ b/encoder/factory_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/architagr/lognugget/enum"
 )
 
-// Test_DefaultEncoderFactory_KnownTypes covers TS-15: JSON and Text
-// resolve to non-nil encoders that honor the Append contract.
 func Test_DefaultEncoderFactory_KnownTypes(t *testing.T) {
 	t.Parallel()
 
@@ -24,10 +22,7 @@ func Test_DefaultEncoderFactory_KnownTypes(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			enc, err := DefaultEncoderFactory(tc.in)
-			if err != nil {
-				t.Fatalf("factory err: %v", err)
-			}
+			enc := DefaultEncoderFactory(tc.in)
 			if enc == nil {
 				t.Fatal("factory returned nil encoder")
 			}
@@ -39,18 +34,28 @@ func Test_DefaultEncoderFactory_KnownTypes(t *testing.T) {
 	}
 }
 
-// Test_DefaultEncoderFactory_UnknownReturnsErr covers TS-18 partial:
-// the current factory rejects unknown types with ErrUnsupportedEncoderType.
-// why: story 008 spec line references "fallback to JSON" (D-10 doc ack) but
-// the actual code surface returns an error. ARCH-2/policy change is out of
-// scope here; this test pins current behavior so a future fallback flip is
-// a deliberate, reviewed change.
-func Test_DefaultEncoderFactory_UnknownReturnsErr(t *testing.T) {
+// Test_DefaultEncoderFactory_GracefulFallback_DocCheck verifies that the
+// graceful variant returns a JSON encoder for unknown types (D-10 fallback).
+func Test_DefaultEncoderFactory_GracefulFallback_DocCheck(t *testing.T) {
 	t.Parallel()
 
-	enc, err := DefaultEncoderFactory(enum.LogEncodeType("bogus"))
-	if !errors.Is(err, ErrUnsupportedEncoderType) {
-		t.Fatalf("want ErrUnsupportedEncoderType, got %v", err)
+	enc := DefaultEncoderFactory(enum.LogEncodeType("bogus"))
+	if enc == nil {
+		t.Fatal("graceful factory must not return nil")
+	}
+	if enc.Name() != "json" {
+		t.Fatalf("graceful fallback must return JSON encoder, got %q", enc.Name())
+	}
+}
+
+// Test_DefaultEncoderFactoryE_UnknownType_ReturnsError verifies that the
+// error variant surfaces ErrUnknownEncoder for unrecognised types.
+func Test_DefaultEncoderFactoryE_UnknownType_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	enc, err := DefaultEncoderFactoryE(enum.LogEncodeType("bogus"))
+	if !errors.Is(err, ErrUnknownEncoder) {
+		t.Fatalf("want ErrUnknownEncoder, got %v", err)
 	}
 	if enc != nil {
 		t.Fatalf("want nil encoder on unknown, got %T", enc)


### PR DESCRIPTION
Fixes #32

## Changes
- `DefaultEncoderFactory(t) Encoder` — graceful, falls back to JSON for unknown types
- `DefaultEncoderFactoryE(t) (Encoder, error)` — surfaces `ErrUnknownEncoder`
- Config callers updated to use appropriate variant
- Tests: `Test_DefaultEncoderFactory_GracefulFallback_DocCheck`, `Test_DefaultEncoderFactoryE_UnknownType_ReturnsError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)