### PR TITLE
feat: TS-13+TS-14 static+context parser tests

### DIFF
--- a/config/parsers_test.go
+++ b/config/parsers_test.go
@@ -1,0 +1,137 @@
+//go:build testing
+
+// Package config_test exercises static-env and context parser contracts
+// (F15, F16, TS-13, TS-14). All sub-tests share the process-wide config
+// singleton and run sequentially under one parallel parent — same strategy
+// as entry_test.Test_LogEntry_Methods — to prevent races.
+package config_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	"github.com/architagr/lognugget/test/support"
+)
+
+// drainN spins until spy has at least n records, then returns them.
+func drainN(t *testing.T, spy *support.FakePreProc, n int) []support.FakePreProcRecord {
+	t.Helper()
+	for i := 0; i < 2000; i++ {
+		if recs := spy.Records(); len(recs) >= n {
+			return recs[:n]
+		}
+		done := make(chan struct{})
+		go func() { close(done) }()
+		<-done
+	}
+	t.Fatalf("timed out waiting for %d log records", n)
+	return nil
+}
+
+// resetParser resets the singleton to debug/JSON defaults and registers spy
+// as the sole pre-processor.
+func resetParser(t *testing.T, name string) *support.FakePreProc {
+	t.Helper()
+	support.NewConfigBuilder(t).MinLevel(enum.LevelDebug).Encoder(enum.EncoderJSON).Build()
+	spy := support.NewFakePreProc(name)
+	config.InitPreProcessors(spy)
+	return spy
+}
+
+// Test_Parsers groups all static + context parser sub-tests sequentially
+// under one parallel parent to prevent singleton races (TS-13, TS-14).
+func Test_Parsers(t *testing.T) {
+	t.Parallel()
+
+	// TS-13: static env parser
+
+	t.Run("StaticEnvParser_EvaluatesOnce", func(t *testing.T) {
+		spy := resetParser(t, "static-eval-spy")
+		stub := support.NewStubStaticParser(map[string]any{"env": "prod"})
+		config.SetStaticEnvFieldsParser(stub.Parser())
+
+		const N = 5
+		for i := 0; i < N; i++ {
+			entry.NewLogEntry().Debug(context.Background(), "msg")
+		}
+		drainN(t, spy, N)
+
+		if got := stub.Evaluations(); got != 1 {
+			t.Fatalf("Evaluations() = %d after %d log calls; want 1 (F15)", got, N)
+		}
+	})
+
+	t.Run("StaticEnvParser_RenderedAppendedToEveryLine", func(t *testing.T) {
+		spy := resetParser(t, "static-rendered-spy")
+		stub := support.NewStubStaticParser(map[string]any{"env": "staging"})
+		config.SetStaticEnvFieldsParser(stub.Parser())
+
+		const N = 3
+		for i := 0; i < N; i++ {
+			entry.NewLogEntry().Info(context.Background(), "check")
+		}
+		recs := drainN(t, spy, N)
+
+		for i, rec := range recs {
+			if !strings.Contains(string(rec.Data), "staging") {
+				t.Errorf("record %d missing static field value %q: %s", i, "staging", rec.Data)
+			}
+		}
+	})
+
+	// TS-14: context fields parser
+
+	t.Run("ContextParser_InvokedPerCall", func(t *testing.T) {
+		spy := resetParser(t, "ctx-per-call-spy")
+		stub := support.NewStubContextParser(map[string]any{"req": "abc"})
+		config.SetContextFieldsParser(stub.Parser())
+
+		const N = 4
+		ctx := context.Background()
+		for i := 0; i < N; i++ {
+			entry.NewLogEntry().Debug(ctx, "msg")
+		}
+		drainN(t, spy, N)
+
+		if got := stub.Calls(); got != N {
+			t.Fatalf("Calls() = %d after %d log calls with non-nil ctx; want %d (F16)", got, N, N)
+		}
+	})
+
+	t.Run("ContextParser_SkippedWhenCtxNil", func(t *testing.T) {
+		spy := resetParser(t, "ctx-nil-spy")
+		stub := support.NewStubContextParser(map[string]any{"req": "abc"})
+		config.SetContextFieldsParser(stub.Parser())
+
+		const N = 3
+		for i := 0; i < N; i++ {
+			entry.NewLogEntry().Debug(nil, "msg") //nolint:staticcheck // intentional nil ctx
+		}
+		drainN(t, spy, N)
+
+		if got := stub.Calls(); got != 0 {
+			t.Fatalf("Calls() = %d with nil ctx; want 0", got)
+		}
+	})
+
+	t.Run("ContextParser_F14Collision", func(t *testing.T) {
+		spy := resetParser(t, "ctx-collision-spy")
+		stub := support.NewStubContextParser(map[string]any{"time": "12:00"})
+		config.SetContextFieldsParser(stub.Parser())
+
+		entry.NewLogEntry().Debug(context.Background(), "collision-check")
+		recs := drainN(t, spy, 1)
+
+		line := string(recs[0].Data)
+		if strings.Contains(line, `"time": "12:00"`) {
+			t.Fatalf("reserved key 'time' must be prefixed; found raw key in: %s", line)
+		}
+		if !strings.Contains(line, "custom.time") {
+			t.Fatalf("expected 'custom.time' in log line: %s", line)
+		}
+	})
+}

--- a/entry/entry.go
+++ b/entry/entry.go
@@ -146,22 +146,18 @@ func (e *LogEntry) logWithSkip(level enum.LogLevel, ctx context.Context, message
 
 	defaultFields := config.GetConfig().DefaultFields()
 	ctxData := e.setLogContextFields(ctx)
-	data := make([]string, 3+len(fields)+len(ctxData), len(fields)+5)
-	i := 0
-	data[i] = config.ParseLogField(defaultFields[enum.DefaultLogKeyTime], customTime.Format(customTime.TimeNow(), config.GetConfig().TimeFormat()))
-	data[i+1] = config.ParseLogField(defaultFields[enum.DefaultLogKeyLevel], level.String())
-	data[i+2] = config.ParseLogField(defaultFields[enum.DefaultLogKeyMessage], message)
-	i += 2
-	for _, field := range fields {
+	data := make([]string, 3+len(fields)+len(ctxData))
+	data[0] = config.ParseLogField(defaultFields[enum.DefaultLogKeyTime], customTime.Format(customTime.TimeNow(), config.GetConfig().TimeFormat()))
+	data[1] = config.ParseLogField(defaultFields[enum.DefaultLogKeyLevel], level.String())
+	data[2] = config.ParseLogField(defaultFields[enum.DefaultLogKeyMessage], message)
+	for j, field := range fields {
 		if _, ok := defaultFields[enum.DefaultLogKey(field.Key)]; ok {
 			field.Key = model.LogAttrKey(config.DefaultPrefix) + field.Key
 		}
-		i++
-		data[i] = config.ParseLogField(string(field.Key), field.Value)
+		data[3+j] = config.ParseLogField(string(field.Key), field.Value)
 	}
-
-	for x, d := range ctxData {
-		data[i+x] = d
+	for j, d := range ctxData {
+		data[3+len(fields)+j] = d
 	}
 	if err != nil {
 		data = append(data, config.ParseLogField(defaultFields[enum.DefaultLogKeyError], err.Error()))


### PR DESCRIPTION
Fixes #33

## Changes
- `config/parsers_test.go`: 5 new tests under single sequential parent (`Test_Parsers`) — avoids singleton races
  - `StaticEnvParser_EvaluatesOnce` (F15: parser evaluated once at registration)
  - `StaticEnvParser_RenderedAppendedToEveryLine` (static fields in every emitted line)
  - `ContextParser_InvokedPerCall` (F16: called N times for N log calls)
  - `ContextParser_SkippedWhenCtxNil` (no call when ctx=nil)
  - `ContextParser_F14Collision` ("time" key → "custom.time")
- `entry/entry.go`: fix `i += 2` indexing bug — context fields overwrote message when no user fields present; replaced with direct index arithmetic

🤖 Generated with [Claude Code](https://claude.com/claude-code)