### PR TITLE
docs: add responsible disclosure policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Importing `lognugget` is sufficient — no `NewLogger()` required.
 
 ---
 
+## Security
+
+Please report suspected vulnerabilities privately through GitHub Security Advisories. See [SECURITY.md](SECURITY.md) for supported versions, reporting details, response targets, and coordinated disclosure guidance.
+
+---
+
 ## Configuration
 
 All setters are optional. Defaults work out of the box.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Supported Versions
+
+LogNugget is currently pre-1.0. Security fixes are accepted for the active `v1.x` development line and the latest release/tag published from it.
+
+## Reporting a Vulnerability
+
+Please do **not** open a public issue for suspected vulnerabilities.
+
+Use GitHub's private vulnerability reporting flow instead:
+
+1. Open this repository's **Security** tab.
+2. Choose **Report a vulnerability**.
+3. Include the details listed below.
+
+If private vulnerability reporting is not yet visible, contact a maintainer listed in `MAINTAINERS.md` and ask for a private reporting channel before sharing exploit details.
+
+## What to Include
+
+Please include enough information for maintainers to reproduce and triage safely:
+
+- LogNugget version, commit, or tag.
+- Go version and operating system.
+- Affected package or API path.
+- Description of the issue and expected impact.
+- Minimal reproduction steps or test case.
+- Any logs, panic output, or relevant configuration.
+- Whether the issue is already public or privately held.
+
+## Response Targets
+
+Maintainers aim to:
+
+- Acknowledge valid-looking reports within **72 hours**.
+- Provide an initial severity/impact assessment within **7 days**.
+- Patch or mitigate critical issues within **14 days** where feasible.
+
+Timelines may vary with severity, reproduction quality, maintainer availability, and whether the fix requires coordinated downstream release work.
+
+## Coordinated Disclosure
+
+Please keep vulnerability details private until maintainers have had a reasonable chance to investigate and release a fix. Reporters will be notified before public disclosure or advisory publication whenever practical.
+
+## Safe Research Boundaries
+
+Please use local tests or your own deployments. Do not attack third-party systems, exfiltrate data, perform denial-of-service testing, or access accounts/data that are not yours.


### PR DESCRIPTION
## Summary
- Add root `SECURITY.md` for responsible disclosure and private GitHub vulnerability reporting.
- Document supported `v1.x` line, report fields, response targets, coordinated disclosure, and safe research boundaries.
- Add a README Security section linking the policy.

Closes #89.

## Verification
- `git diff --check`
- Direct marker inspection for required issue fields: v1.x support, private GitHub reporting, Go/LogNugget report details, 72-hour acknowledgement, 14-day critical patch target, coordinated disclosure, and README link.

Note: the repository setting to enable private vulnerability reporting still needs maintainer/admin action in GitHub Settings → Security → Advisories.
