### PR TITLE
perf(p5): channel capacity 1000 + SetChannelCapacity API

### DIFF
--- a/config/channel_capacity_test.go
+++ b/config/channel_capacity_test.go
@@ -1,0 +1,67 @@
+//go:build testing
+
+package config_test
+
+import (
+	"bytes"
+	"log"
+	"testing"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func resetCapacity(t *testing.T) {
+	t.Helper()
+	config.TestResetChannelCapacity()
+	config.TestResetConfig()
+}
+
+func Test_DafaultLogBuffer_Value(t *testing.T) {
+	assert.Equal(t, 1000, config.DafaultLogBuffer, "DafaultLogBuffer must be 1000")
+}
+
+func Test_SetChannelCapacity_DefaultIs1000(t *testing.T) {
+	resetCapacity(t)
+	assert.Equal(t, 1000, config.GetChannelCapacity())
+}
+
+func Test_SetChannelCapacity_ValidValue(t *testing.T) {
+	resetCapacity(t)
+	config.SetChannelCapacity(5000)
+	assert.Equal(t, 5000, config.GetChannelCapacity())
+	t.Cleanup(config.TestResetChannelCapacity)
+}
+
+func Test_SetChannelCapacity_ZeroClamped(t *testing.T) {
+	resetCapacity(t)
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(nil) })
+
+	config.SetChannelCapacity(0)
+	assert.Equal(t, 1000, config.GetChannelCapacity(), "zero must clamp to 1000")
+	assert.Contains(t, buf.String(), "SetChannelCapacity")
+}
+
+func Test_SetChannelCapacity_NegativeClamped(t *testing.T) {
+	resetCapacity(t)
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(nil) })
+
+	config.SetChannelCapacity(-5)
+	assert.Equal(t, 1000, config.GetChannelCapacity(), "negative must clamp to 1000")
+	assert.Contains(t, buf.String(), "SetChannelCapacity")
+}
+
+func Test_SetChannelCapacity_OverMaxClamped(t *testing.T) {
+	resetCapacity(t)
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(nil) })
+
+	config.SetChannelCapacity(200_000)
+	assert.Equal(t, 100_000, config.GetChannelCapacity(), "over-max must clamp to 100_000")
+	assert.Contains(t, buf.String(), "SetChannelCapacity")
+}

--- a/config/channel_capacity_test.go
+++ b/config/channel_capacity_test.go
@@ -31,13 +31,15 @@ func Test_SetChannelCapacity_ValidValue(t *testing.T) {
 	config.SetChannelCapacity(5000)
 	assert.Equal(t, 5000, config.GetChannelCapacity())
 	t.Cleanup(config.TestResetChannelCapacity)
+	t.Cleanup(config.TestResetConfig)
 }
 
 func Test_SetChannelCapacity_ZeroClamped(t *testing.T) {
 	resetCapacity(t)
 	var buf bytes.Buffer
+	prev := log.Writer()
 	log.SetOutput(&buf)
-	t.Cleanup(func() { log.SetOutput(nil) })
+	t.Cleanup(func() { log.SetOutput(prev) })
 
 	config.SetChannelCapacity(0)
 	assert.Equal(t, 1000, config.GetChannelCapacity(), "zero must clamp to 1000")
@@ -47,8 +49,9 @@ func Test_SetChannelCapacity_ZeroClamped(t *testing.T) {
 func Test_SetChannelCapacity_NegativeClamped(t *testing.T) {
 	resetCapacity(t)
 	var buf bytes.Buffer
+	prev := log.Writer()
 	log.SetOutput(&buf)
-	t.Cleanup(func() { log.SetOutput(nil) })
+	t.Cleanup(func() { log.SetOutput(prev) })
 
 	config.SetChannelCapacity(-5)
 	assert.Equal(t, 1000, config.GetChannelCapacity(), "negative must clamp to 1000")
@@ -58,8 +61,9 @@ func Test_SetChannelCapacity_NegativeClamped(t *testing.T) {
 func Test_SetChannelCapacity_OverMaxClamped(t *testing.T) {
 	resetCapacity(t)
 	var buf bytes.Buffer
+	prev := log.Writer()
 	log.SetOutput(&buf)
-	t.Cleanup(func() { log.SetOutput(nil) })
+	t.Cleanup(func() { log.SetOutput(prev) })
 
 	config.SetChannelCapacity(200_000)
 	assert.Equal(t, 100_000, config.GetChannelCapacity(), "over-max must clamp to 100_000")

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ package config
 import (
 	"context"
 	"io"
+	"log"
 	"os"
 	"strings"
 	"sync"
@@ -34,7 +35,7 @@ var (
 	DefaultAddSource  bool      = false
 	DefaultOutput     io.Writer = os.Stdout    // Default output writer
 	DefaultTimeFormat string    = time.RFC3339 // Default time format for log entries
-	DafaultLogBuffer  int       = 20           // Default buffer size for logs
+	DafaultLogBuffer  int       = 1000         // Default buffer size for logs
 	DefaultPrefix     string    = "custom."
 )
 
@@ -52,6 +53,16 @@ var atomicMinLevel atomic.Int64
 // store is lossless. If LogLevel ever widens beyond int64 this line will
 // produce a compile error, not a silent data truncation.
 var _ int64 = int64(enum.LevelFatal)
+
+// channelCapacity is the buffer size used when resetConfig creates the
+// dispatch channel. Set via SetChannelCapacity before init() fires.
+// Range: [1, 100_000]; values outside this range are clamped with a warning.
+// Stored as atomic.Int64 so concurrent test helpers can write it safely under -race.
+var channelCapacity atomic.Int64
+
+const channelCapacityMax = 100_000
+
+func init() { channelCapacity.Store(int64(DafaultLogBuffer)) }
 
 // ContextFieldsAppender is a function that appends per-request context fields
 // directly to dst as pre-serialised bytes and returns the extended slice.
@@ -481,6 +492,32 @@ func SetContextFieldsAppender(appender ContextFieldsAppender) {
 	defaultConfig.contextAppender = appender
 }
 
+// SetChannelCapacity sets the buffer size for the dispatch channel created by
+// the next resetConfig call. Must be called before init() fires (Go
+// init-ordering guarantee) and before InitPreProcessors. No configMu needed —
+// the variable is written once at startup, read once in resetConfig.
+//
+// Values ≤ 0 are clamped to DafaultLogBuffer (1000); values > 100_000 are
+// clamped to 100_000. A log.Printf warning is emitted for out-of-range values.
+func SetChannelCapacity(n int) {
+	if n <= 0 || n > channelCapacityMax {
+		log.Printf("SetChannelCapacity(%d): out of range [1, %d]; clamping to default %d", n, channelCapacityMax, DafaultLogBuffer)
+		if n > channelCapacityMax {
+			channelCapacity.Store(int64(channelCapacityMax))
+		} else {
+			channelCapacity.Store(int64(DafaultLogBuffer))
+		}
+		return
+	}
+	channelCapacity.Store(int64(n))
+}
+
+// GetChannelCapacity returns the current channel capacity value.
+// Exposed for testing; not intended for production use.
+func GetChannelCapacity() int {
+	return int(channelCapacity.Load())
+}
+
 // RegisterHook registers hook to be invoked whenever a log event at
 // level is dispatched. Safe for concurrent use.
 func RegisterHook(level enum.LogLevel, hook PublishLogMessageHookContract) {
@@ -586,7 +623,7 @@ func ProcessLogEvent() {
 func resetConfig() {
 	// Build the new config and channel before acquiring the lock to
 	// minimise lock-hold time — encoder factory can take allocations.
-	newCh := make(chan LogEvent, 10)
+	newCh := make(chan LogEvent, int(channelCapacity.Load()))
 	encoderObj := encoder.DefaultEncoderFactory(enum.EncoderJSON)
 	newCfg := &Config{
 		minLevel:           DafaultLevel,

--- a/config/test_only_helpers.go
+++ b/config/test_only_helpers.go
@@ -19,3 +19,7 @@ package config
 // helper keeps the production API surface free of this foot-gun while
 // still letting test/support and config_test reach the reset path.
 func TestResetConfig() { resetConfig() }
+
+// TestResetChannelCapacity resets channelCapacity to DafaultLogBuffer.
+// Call before TestResetConfig in capacity-specific tests that need a known state.
+func TestResetChannelCapacity() { channelCapacity.Store(int64(DafaultLogBuffer)) }

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # LogNugget — Live Status Dashboard
 
-> **Last updated:** 2026-05-18
+> **Last updated:** 2026-05-21
 > **v1.0.0:** Released ✅ — [tag v1.0.0](https://github.com/architagr/LogNugget/releases/tag/v1.0.0) · [PR #80](https://github.com/architagr/LogNugget/pull/80) (merged)
 > **Umbrella:** [#12](https://github.com/architagr/LogNugget/issues/12)
 
@@ -198,6 +198,19 @@ idempotent `Shutdown()`, zero-config `init()`, race-clean under `-race`, SC8 fan
 
 ---
 
+## Critical Path to v1.0.0
+
+![Critical Path](assets/critical-path.svg)
+
+```text
+[A ✅][B ✅] → [C ✅] → [D ✅] → [029 ✅][030 ✅][031 ✅] → [032 🚀] → v1.0.0 PR #80
+```
+
+**All stories complete.** Release PR [#80](https://github.com/architagr/LogNugget/pull/80) is open for review.
+SLO miss (hot-path 2× over 1 µs) does NOT block v1.0.0 per project decision — tracked post-release.
+
+---
+
 ## Epic V2 — Performance: close the 31× throughput gap vs zerolog
 
 > **Umbrella:** [#81](https://github.com/architagr/LogNugget/issues/81)
@@ -205,12 +218,16 @@ idempotent `Shutdown()`, zero-config `init()`, race-clean under `-race`, SC8 fan
 
 ### The gap
 
-| Metric | zerolog (parallel) | LogNugget (parallel) | Gap |
-| ------ | ------------------ | -------------------- | --- |
-| ns/op | ~110 | ~3,440 | 31× slower |
-| ops/sec | ~9.09 M | ~290 K | 31× fewer |
-| allocs/op | 0 | 55 | ∞ |
-| B/op | 0 | 2,909 | ∞ |
+| Metric | zerolog (parallel) | LogNugget pre-V2 | LogNugget after P1 | Target (P1–P5) | Gap (pre-V2) |
+| ------ | ------------------ | ---------------- | ------------------ | -------------- | ------------ |
+| ns/op | ~110 | ~3,440 | ~1,130 | < 1,000 | 31× slower |
+| ops/sec | ~9.09 M | ~290 K | ~885 K | > 1 M | 31× fewer |
+| allocs/op | 0 | 55 | ~32 | ~0 | ∞ |
+| B/op | 0 | 2,909 | ~1,400 | ~0 | ∞ |
+
+> P1 measured on `BenchmarkLognugget_Parallel_10CtxFields` (GOMAXPROCS=8). P2 removes ~30 interface-boxing allocs;
+> P3 eliminates ~600 ns / ~23 allocs from `map[string]any` context iteration; P5 eliminates channel backpressure.
+> P4 (inline encoder framing) removes 2 allocs from double-buffer `en.Append`. Combined target: < 1,000 ns/op, ≤ 5 allocs.
 
 ### Root causes (ranked by impact)
 
@@ -227,10 +244,10 @@ idempotent `Shutdown()`, zero-config `init()`, race-clean under `-race`, SC8 fan
 | # | Issue | Story | Status |
 |---|-------|-------|--------|
 | P1 | [#82](https://github.com/architagr/LogNugget/issues/82) | Atomic minLevel + single config snapshot per call | ✅ DONE (PR [#94](https://github.com/architagr/LogNugget/pull/94)) |
-| P2 | [#83](https://github.com/architagr/LogNugget/issues/83) | Typed field API — Str/Int/Bool/Float64 on LogEntry | 🔍 IN REVIEW (PR [#95](https://github.com/architagr/LogNugget/pull/95)) |
-| P3 | [#84](https://github.com/architagr/LogNugget/issues/84) | Append-to-buf context API — eliminate map[string]any | 📋 PLANNED |
+| P2 | [#83](https://github.com/architagr/LogNugget/issues/83) | Typed field API — Str/Int/Bool/Float64 on LogEntry | ✅ MERGED (PR [#95](https://github.com/architagr/LogNugget/pull/95)) |
+| P3 | [#84](https://github.com/architagr/LogNugget/issues/84) | Append-to-buf context API — eliminate map[string]any | ✅ MERGED (PR [#96](https://github.com/architagr/LogNugget/pull/96)) |
 | P4 | [#85](https://github.com/architagr/LogNugget/issues/85) | Inline framing — eliminate en.Append double-buffer | 📋 PLANNED |
-| P5 | [#86](https://github.com/architagr/LogNugget/issues/86) | Channel capacity ≥ 1000 + configurable | 📋 PLANNED |
+| P5 | [#86](https://github.com/architagr/LogNugget/issues/86) | Channel capacity ≥ 1000 + configurable | 🔄 DRAFT PR [#97](https://github.com/architagr/LogNugget/pull/97) |
 
 ### Where LogNugget wins today
 
@@ -254,19 +271,6 @@ idempotent `Shutdown()`, zero-config `init()`, race-clean under `-race`, SC8 fan
 | OS3 | [#90](https://github.com/architagr/LogNugget/issues/90) | golangci-lint config + GitHub Actions CI | 📋 PLANNED |
 | OS4 | [#91](https://github.com/architagr/LogNugget/issues/91) | godoc audit — all exported symbols documented | 📋 PLANNED |
 | OS5 | [#92](https://github.com/architagr/LogNugget/issues/92) | API stability contract + CHANGELOG | 📋 PLANNED |
-
----
-
-## Critical Path to v1.0.0
-
-![Critical Path](assets/critical-path.svg)
-
-```
-[A ✅][B ✅] → [C ✅] → [D ✅] → [029 ✅][030 ✅][031 ✅] → [032 🚀] → v1.0.0 PR #80
-```
-
-**All stories complete.** Release PR [#80](https://github.com/architagr/LogNugget/pull/80) is open for review.
-SLO miss (hot-path 2× over 1 µs) does NOT block v1.0.0 per project decision — tracked post-release.
 
 ---
 

--- a/entry/parallel_bench_test.go
+++ b/entry/parallel_bench_test.go
@@ -1,0 +1,51 @@
+package entry_test
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	pipelineStage "github.com/architagr/lognugget/pipeline_stage"
+)
+
+type parallelBenchWriter struct{}
+
+func (w *parallelBenchWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// BenchmarkLognugget_Parallel_10CtxFields is the final integration gate for
+// the full V2 stack (P1-P5 combined). At GOMAXPROCS=8 the channel buffer of
+// 1000 eliminates back-pressure; target ≤ 1,000 ns/op.
+func BenchmarkLognugget_Parallel_10CtxFields(b *testing.B) {
+	b.StopTimer()
+	prev := runtime.GOMAXPROCS(8)
+	b.Cleanup(func() { runtime.GOMAXPROCS(prev) })
+
+	out := &parallelBenchWriter{}
+	config.SetMinLevel(enum.LevelDebug)
+	config.SetEncoderType(enum.EncoderJSON)
+	config.SetContextFieldsParser(func(ctx context.Context) map[string]any {
+		return map[string]any{
+			"k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4", "k5": "v5",
+			"k6": "v6", "k7": "v7", "k8": "v8", "k9": "v9", "k10": "v10",
+		}
+	})
+	unset := pipelineStage.NewUnsetLogEventPostProcessor(2*time.Second, 1000, out)
+	pipelineStage.EventPreProcessorObj.RegisterHook(enum.LevelUnSet, unset)
+	config.InitPreProcessors(pipelineStage.EventPreProcessorObj)
+	entry.GenerateInitialPool(100_000)
+	b.Cleanup(unset.Stop)
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			entry.NewLogEntry().Debug(ctx, "parallel bench")
+		}
+	})
+}

--- a/test/integration/pipeline_test.go
+++ b/test/integration/pipeline_test.go
@@ -30,6 +30,12 @@ import (
 //  3. Fill remaining channel capacity (bufSize-1 more events — channel is now full).
 //  4. Assert next send blocks; Release hook; assert unblocks.
 func Test_Integration_ChannelBuffersAndBlocks(t *testing.T) {
+	const bufSize = 10
+	// Set capacity to 10 and reset to apply it, then register cleanup to restore.
+	config.SetChannelCapacity(bufSize)
+	t.Cleanup(config.TestResetChannelCapacity)
+	config.TestResetConfig()
+
 	support.NewConfigBuilder(t).
 		MinLevel(enum.LevelDebug).
 		Build()
@@ -38,8 +44,6 @@ func Test_Integration_ChannelBuffersAndBlocks(t *testing.T) {
 	entered := make(chan struct{})
 	spy := &slowPreProcSignal{hook: slow, entered: entered}
 	config.InitPreProcessors(spy)
-
-	const bufSize = 10 // matches config.ch buffer (make(chan LogEvent, 10))
 	payload := []byte(`{"level":"info","msg":"x"}`)
 
 	// Trigger ProcessLogEvent to pick up and block on the first event.


### PR DESCRIPTION
Fixes #86

## Summary

- Raise DafaultLogBuffer 20 to 1000; dispatch channel absorbs burst traffic and reduces backpressure under parallel load
- channelCapacity atomic.Int64 (race-safe) with SetChannelCapacity clamped to [1..100_000]
- GetChannelCapacity + TestResetChannelCapacity for test isolation
- Integration test Test_Integration_ChannelBuffersAndBlocks now pins cap=10 via explicit SetChannelCapacity+TestResetConfig so the blocking assertion stays deterministic
- BenchmarkLognugget_Parallel_10CtxFields (GOMAXPROCS=8, 10 ctx fields) validates the parallel path; will be the final gate check after P1-P5 merge

## Note on bench gate
Individual story bench gate exits 1 — the 1000 ns/op target requires all 5 V2 stories combined. Gate will pass on feat/81-v2-performance after all branches merge.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>