### PR TITLE
perf(p4): inline encoder framing + ownership transfer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -244,6 +244,17 @@ func AddPreProcessors(observers ...preProcessingObserverContract) {
 	}
 }
 
+// HasEventPreProcessors reports whether at least one pre-processor is
+// registered. It acquires configMu.RLock so it is safe for concurrent use and
+// produces no data races. The hot path in logWithSkip calls this instead of
+// reading EventPreProcessors directly (which is an unsynchronised map access).
+func HasEventPreProcessors() bool {
+	configMu.RLock()
+	n := len(EventPreProcessors)
+	configMu.RUnlock()
+	return n > 0
+}
+
 // RemovePreProcessor deletes the named pre-processor from the global map.
 // It is safe to call concurrently.
 func RemovePreProcessor(name string) {

--- a/config/config.go
+++ b/config/config.go
@@ -308,40 +308,27 @@ func SetOutput(output io.Writer) {
 	defaultConfig.output = output
 }
 
-// PublishLog makes a defensive copy of Data and sends the event onto
-// the dispatch channel. Safe for concurrent use; callers block if the
-// channel buffer is full.
+// PublishLog sends Data onto the dispatch channel. Safe for concurrent use;
+// callers block if the channel buffer is full (back-pressure, F23).
 //
-// why (ARCH-7 / NF3): entry.logWithSkip passes the encoder's output
-// buffer as Data. That buffer may share backing memory with a
-// sync.Pool-owned slice that the caller returns to the pool immediately
-// after this call returns. The background ProcessLogEvent goroutine
-// reads LogEvent.Data asynchronously; without a copy, the goroutine
-// and the pool recycler race on the same backing array.
+// why (P4 ownership transfer): entry.logWithSkip now transfers ownership of
+// its pooled buf before calling PublishLog — e.buf is severed with a fresh
+// make([]byte, 0, initBufCap) and e.Put() is called only after PublishLog
+// returns. Data therefore has exclusive ownership; the background goroutine
+// (ProcessLogEvent) can read it safely without a defensive copy.
 //
-// The copy is `append([]byte(nil), Data...)` rather than a
-// bytes.Clone-style helper so the allocation is explicit and
-// auditable. It produces exactly 1 heap alloc (~len(Data) bytes) per
-// event — the accepted NF3 cost for crossing the goroutine boundary
-// safely (see bench-baseline.txt, ARCH-7 story).
-//
-// why (lock discipline): the RLock is taken only for the pointer
-// snapshot of ch, not across the send itself. resetConfig never closes
-// the old channel (see comment there), so there is no risk of a "send
-// on closed channel" panic. Releasing the RLock before the send avoids
-// holding it during a potentially blocking channel operation.
+// why (lock discipline): the RLock is taken only for the pointer snapshot of
+// ch, not across the send itself. resetConfig never closes the old channel
+// (see comment there), so there is no "send on closed channel" risk.
+// Releasing the RLock before the send avoids holding it during a potentially
+// blocking channel operation.
 func PublishLog(Level enum.LogLevel, Data []byte) {
-	// why: copy before acquiring the lock so we do not hold configMu
-	// across the allocation. The copy is safe to perform outside the
-	// lock: Data is caller-owned at this point, and the only race we
-	// guard against (pool recycling) happens after the call returns.
-	dataCopy := append([]byte(nil), Data...)
 	configMu.RLock()
 	currentCh := ch
 	configMu.RUnlock()
 	currentCh <- LogEvent{
 		Level: Level,
-		Data:  dataCopy,
+		Data:  Data,
 	}
 }
 

--- a/config/publish_test.go
+++ b/config/publish_test.go
@@ -1,13 +1,24 @@
 //go:build testing
 
-// Package config_test covers ARCH-7 / Story 024: LogEvent.Data copy semantics.
+// Package config_test covers ARCH-7 / Story 024 + Epic V2 P4: LogEvent.Data
+// ownership semantics.
 //
-// These tests verify that PublishLog makes an independent copy of the caller's
-// byte slice before putting it on the dispatch channel. The invariant matters
-// because entry.logWithSkip passes an encoder output buffer that may be returned
-// to a sync.Pool immediately after calling PublishLog. Without a defensive copy,
-// a race exists between the background ProcessLogEvent goroutine reading
-// LogEvent.Data and the pool recycling the same backing array.
+// Pre-P4: PublishLog made a defensive copy (ARCH-7). The copy ensured that
+// callers returning e.buf to sync.Pool immediately after calling PublishLog
+// could not race with the background ProcessLogEvent goroutine.
+//
+// P4 (Epic V2 inline framing): the defensive copy was moved upstream into
+// entry.logWithSkip. logWithSkip now steals e.buf with:
+//
+//	data := e.buf
+//	e.buf = make([]byte, 0, initBufCap)   // sever alias — fresh backing array
+//	config.PublishLog(level, data)        // data has exclusive ownership
+//	e.Put()                               // pool gets fresh buf, not data
+//
+// PublishLog no longer copies. Callers MUST transfer exclusive ownership of
+// the slice before calling PublishLog; they must not modify or pool-return the
+// slice after the call. Direct callers of PublishLog (outside logWithSkip) are
+// responsible for making their own copy if needed.
 //
 // All sub-tests run sequentially under the parallel parent Test_PublishLog so
 // they do not race on the singleton against Test_Race_ResetConfig_UnderConcurrentSet
@@ -15,10 +26,10 @@
 // used by Test_Parsers and Test_LogEntry_Methods in this module.
 //
 // Three sub-tests are defined:
-//   - DataNotAliasedToPool  — correctness: mutation of caller's buf after call
-//     does not affect the dispatched LogEvent.Data
-//   - AllocsOneCopy         — alloc budget guard (NF3): verifies >= 1 and <= 5
-//     allocs/call with a 128-byte payload
+//   - DataOwnershipTransfer — correctness: caller transfers owned slice to
+//     PublishLog; verifies the data arrives intact at the pre-processor
+//   - AllocsZeroCopy        — alloc budget guard (P4): PublishLog itself now
+//     allocates 0 copies; the sole channel-box alloc is <= 1
 //   - RaceConcurrent        — 100 goroutines each publish 1 event; -race must be
 //     clean; all 100 events must be delivered
 package config_test
@@ -98,59 +109,47 @@ func setupPublishSpy(t *testing.T, name string) *support.FakePreProc {
 // time out waiting for its spy to be invoked.
 func Test_PublishLog(t *testing.T) {
 
-	// DataNotAliasedToPool verifies that the LogEvent.Data byte slice received by
-	// a pre-processor is independent of the buffer originally passed to PublishLog.
+	// DataOwnershipTransfer verifies that when the caller transfers ownership of a
+	// slice to PublishLog (P4 contract: caller must not retain or modify the slice
+	// after the call), the data arrives intact at the pre-processor.
 	//
-	// Steps:
-	//  1. Call PublishLog with a known slice ("original-content").
-	//  2. Immediately overwrite every byte of the original slice with 'X'.
-	//  3. Assert the spy received "original-content", not "XXXXXXXXXXXXXXXX".
+	// This replaces the pre-P4 DataNotAliasedToPool test which asserted that
+	// PublishLog made a defensive copy. P4 moved the copy responsibility upstream
+	// into entry.logWithSkip (ownership transfer via e.buf steal + fresh make).
 	//
-	// Acceptance criterion 1 of Story 024 (ARCH-7): LogEvent.Data is a fresh
-	// allocation reflecting the bytes at call time, not the bytes present when
-	// the dispatcher goroutine reads the event.
-	t.Run("DataNotAliasedToPool", func(t *testing.T) {
-		spy := setupPublishSpy(t, "alias-spy")
+	// Acceptance criterion: LogEvent.Data received by the pre-processor matches
+	// the bytes passed to PublishLog at call time.
+	t.Run("DataOwnershipTransfer", func(t *testing.T) {
+		spy := setupPublishSpy(t, "ownership-spy")
 
-		original := []byte("original-content")
-		config.PublishLog(enum.LevelInfo, original)
-
-		// Simulate pool recycling: overwrite every byte immediately after call.
-		// If PublishLog aliased Data to original, the spy sees "XXXXXXXXXXXXXXXX".
-		for i := range original {
-			original[i] = 'X'
-		}
+		// Caller owns this slice and will not touch it after calling PublishLog,
+		// simulating the P4 ownership transfer in logWithSkip.
+		owned := []byte("original-content")
+		config.PublishLog(enum.LevelInfo, owned)
 
 		got := drainPublishSpy(t, spy)
 
 		const want = "original-content"
 		if string(got) != want {
-			t.Errorf("LogEvent.Data = %q after caller mutation; want %q\n"+
-				"hint: PublishLog must copy Data before sending on the channel (ARCH-7)",
+			t.Errorf("LogEvent.Data = %q; want %q\n"+
+				"hint: P4 ownership transfer — PublishLog must deliver Data intact",
 				string(got), want)
 		}
-
-		// Drain: only 1 event sent; already verified above. No extra wait needed.
 	})
 
-	// AllocsOneCopy documents the allocation budget of a PublishLog call under
-	// the NF3 alloc-accounting requirement.
+	// AllocsZeroCopy documents the P4 allocation budget: PublishLog itself now
+	// performs 0 copies (no append([]byte(nil), Data...)). The sole alloc is the
+	// LogEvent value boxed into the channel's ring buffer, which the Go runtime
+	// may or may not escape to the heap.
 	//
-	// Expected: 2 allocs/op — 1 for append([]byte(nil), Data...) (the defensive
-	// copy mandated by ARCH-7) plus 1 for the LogEvent value boxed into the
-	// channel's ring buffer. A count of 0 means the copy was removed (aliasing
-	// defect). A count > 5 signals unexpected heap pressure.
-	//
-	// why: NF3 requires one identifiable alloc per published event (~600 B). This
-	// AllocsPerRun measurement is the canonical proof that no regression to zero
-	// copies (aliasing) or excessive copies has occurred.
+	// P4 change: the defensive copy moved into entry.logWithSkip (ownership
+	// transfer: e.buf steal + make([]byte, 0, initBufCap)). PublishLog must not
+	// re-introduce a copy.
 	//
 	// Isolation: we wait for all sent events to drain before returning so that
-	// events from AllocsPerRun's burst (101 calls) are fully processed before
-	// RaceConcurrent installs its spy. Without this drain, in-flight events from
-	// the old channel goroutine would be forwarded to RaceConcurrent's spy
-	// (ProcessLogEvent reads the live EventPreProcessors map, not a snapshot).
-	t.Run("AllocsOneCopy", func(t *testing.T) {
+	// events from AllocsPerRun's burst are fully processed before RaceConcurrent
+	// installs its spy.
+	t.Run("AllocsZeroCopy", func(t *testing.T) {
 		sink := support.NewFakePreProc("alloc-sink")
 		config.TestResetConfig()
 		config.InitPreProcessors(sink)
@@ -161,30 +160,22 @@ func Test_PublishLog(t *testing.T) {
 			payload[i] = byte('a' + i%26)
 		}
 
-		// Track exactly how many events are sent during the measurement so we can
-		// wait for them all to drain before returning from this sub-test.
 		var sent int
 		allocs := testing.AllocsPerRun(100, func() {
 			config.PublishLog(enum.LevelInfo, payload)
 			sent++
 		})
 
-		// why: ProcessLogEvent already runs via the goroutine started by
-		// resetConfig. We wait for all sent events to be acknowledged by the sink
-		// so the subsequent RaceConcurrent sub-test does not inherit in-flight events.
 		waitForDrain(sink, sent, 5*time.Second)
 
 		t.Logf("AllocsPerRun for PublishLog with 128-byte payload: %.1f allocs/op", allocs)
 
-		// A count of 0 means no copy — ARCH-7 violated. Even the pre-fix channel
-		// boxing gives 1, so after the fix we expect exactly 2. Guard both ends.
-		if allocs < 1 {
-			t.Errorf("PublishLog reported %.1f allocs: expected >= 1 (ARCH-7 copy + channel box). "+
-				"Verify that append([]byte(nil), Data...) is present in PublishLog.", allocs)
-		}
-		if allocs > 5 {
-			t.Errorf("PublishLog reported %.1f allocs; expected <= 5 (NF3 budget). "+
-				"Investigate unexpected heap pressure on the publish path.", allocs)
+		// P4: PublishLog must not copy Data — 0 allocs for the copy.
+		// The channel-box alloc may or may not be counted (runtime-dependent).
+		// Guard the upper end: anything > 2 indicates unexpected heap pressure.
+		if allocs > 2 {
+			t.Errorf("PublishLog reported %.1f allocs; expected <= 2 (P4: no Data copy). "+
+				"Check whether append([]byte(nil), Data...) was re-introduced.", allocs)
 		}
 	})
 
@@ -192,16 +183,16 @@ func Test_PublishLog(t *testing.T) {
 	// that all 100 events reach the pre-processor.
 	//
 	// Running with `go test -race -tags testing` must produce no DATA RACE
-	// reports — this is the canonical proof of ARCH-7's "no aliasing across
-	// goroutine boundary" requirement. Each goroutine shares the same payload
-	// slice; PublishLog's copy ensures the dispatcher never reads from a slice
-	// that is concurrently written by another goroutine.
+	// reports. Each goroutine passes the same payload slice to PublishLog; since
+	// no goroutine writes to payload after setup, reading from multiple goroutines
+	// concurrently is race-free. ProcessLogEvent reads each LogEvent.Data slice
+	// without writing to it, so concurrent reads across goroutines are safe.
+	//
+	// P4 note: this is the correct usage pattern — goroutines pass a read-only
+	// (or exclusively-owned) slice to PublishLog and do not touch it afterwards.
 	//
 	// why: numPublishes=1 keeps total sent (100) well within the channel buffer
-	// capacity (10 × drain rate). Larger bursts (e.g. 100×100) block goroutines
-	// in the channel send and allow other parallel tests' TestResetConfig calls
-	// to redirect in-flight events to their spy, breaking the exact count
-	// assertion. The race detector — not the count — is the primary correctness
+	// capacity. The race detector — not the count — is the primary correctness
 	// signal; the count assertion is a secondary liveness check.
 	t.Run("RaceConcurrent", func(t *testing.T) {
 		const (

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -29,9 +29,8 @@ var ErrUnknownEncoder = errors.New("unknown encoder type")
 //
 // OpenBytes returns the constant bytes that open an encoded log record (e.g.
 // `{` for JSON). The returned slice is immutable; callers must not modify it.
-// P4 will use OpenBytes and CloseBytes to build streaming encoders; P1 adds
-// these stubs so GetHotSnapshot can pre-fetch them once per call, outside the
-// configMu lock.
+// logWithSkip prepends these bytes directly into e.buf to avoid an intermediate
+// allocation (P4 inline framing).
 //
 // CloseBytes returns the constant bytes that close an encoded log record (e.g.
 // `}\n` for JSON). The returned slice is immutable; callers must not modify it.
@@ -41,6 +40,23 @@ type Encoder interface {
 	OpenBytes() []byte
 	CloseBytes() []byte
 }
+
+// noopCloseBytesNewline is the single shared "\n" slice returned by
+// NoopFramer.CloseBytes so every call returns the same immutable bytes.
+var noopCloseBytesNewline = []byte{'\n'}
+
+// NoopFramer is an embeddable struct that provides default OpenBytes/CloseBytes
+// implementations suitable for encoder types that need no opening delimiter.
+// Embed it in a custom Encoder to avoid writing these methods from scratch:
+//
+//	type MyEncoder struct { encoder.NoopFramer; ... }
+//
+// OpenBytes returns nil (no opening bytes).
+// CloseBytes returns "\n" (universal newline terminator, ARCH-14).
+type NoopFramer struct{}
+
+func (NoopFramer) OpenBytes() []byte { return nil }
+func (NoopFramer) CloseBytes() []byte { return noopCloseBytesNewline }
 
 // DefaultEncoderFactory returns the Encoder for the given LogEncodeType.
 // For unknown types it falls back to the JSON encoder.

--- a/encoder/framing_test.go
+++ b/encoder/framing_test.go
@@ -1,0 +1,49 @@
+package encoder_test
+
+import (
+	"testing"
+
+	"github.com/architagr/lognugget/encoder"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_JSONEncoder_OpenCloseBytes(t *testing.T) {
+	t.Parallel()
+	enc := encoder.NewJSONEncoder()
+	assert.Equal(t, []byte{'{'}, enc.OpenBytes(), "OpenBytes must return opening brace")
+	assert.Equal(t, []byte{'}', '\n'}, enc.CloseBytes(), "CloseBytes must return closing brace + newline")
+}
+
+func Test_TextEncoder_OpenCloseBytes(t *testing.T) {
+	t.Parallel()
+	enc := encoder.NewTextEncoder()
+	assert.Nil(t, enc.OpenBytes(), "TextEncoder OpenBytes must return nil")
+	assert.Equal(t, []byte{'\n'}, enc.CloseBytes(), "TextEncoder CloseBytes must return newline")
+}
+
+// Test_NoopFramer_Defaults verifies the NoopFramer embeddable struct satisfies
+// the framing contract: OpenBytes nil (no opener), CloseBytes "\n" (newline terminator).
+// Third-party encoder implementations can embed NoopFramer to satisfy the
+// Encoder interface without writing OpenBytes/CloseBytes from scratch.
+func Test_NoopFramer_Defaults(t *testing.T) {
+	t.Parallel()
+	var nf encoder.NoopFramer
+	assert.Nil(t, nf.OpenBytes(), "NoopFramer.OpenBytes must return nil")
+	assert.Equal(t, []byte{'\n'}, nf.CloseBytes(), "NoopFramer.CloseBytes must return newline")
+}
+
+func Test_Append_BackwardCompat(t *testing.T) {
+	t.Parallel()
+	t.Run("json", func(t *testing.T) {
+		t.Parallel()
+		enc := encoder.NewJSONEncoder()
+		got := enc.Append(nil, []byte("k:v"))
+		assert.Equal(t, "{k:v}\n", string(got), "JSON Append must wrap body in braces + newline")
+	})
+	t.Run("text", func(t *testing.T) {
+		t.Parallel()
+		enc := encoder.NewTextEncoder()
+		got := enc.Append(nil, []byte("k=v"))
+		assert.Equal(t, "k=v\n", string(got), "Text Append must append newline only")
+	})
+}

--- a/entry/entry.go
+++ b/entry/entry.go
@@ -75,11 +75,11 @@ func (e *LogEntry) reset() {
 // after publishing; callers should not invoke it directly unless they abandon
 // an entry without logging.
 //
-// Safety after PublishLog: by the time Put is called, the encoded bytes have
-// already been passed to config.PublishLog, which copies them into a fresh
-// []byte before sending the LogEvent onto the dispatch channel (ARCH-7). The
-// backing array of the encoder's output buffer therefore has no live readers;
-// Put (and any subsequent pool reuse) cannot race with ProcessLogEvent.
+// Safety after PublishLog (P4 ownership-transfer model): logWithSkip transfers
+// ownership of e.buf to config.PublishLog by severing the alias before calling
+// Put — the slice sent to the channel is a distinct allocation from the buffer
+// retained by the pool. Put therefore cannot race with ProcessLogEvent reading
+// the dispatched bytes.
 func (e *LogEntry) Put() {
 	entryPool.Put(e)
 }
@@ -135,7 +135,7 @@ func (e *LogEntry) logWithSkip(level enum.LogLevel, ctx context.Context, message
 		e.Put()
 		return
 	}
-	if config.EventPreProcessors == nil {
+	if !config.HasEventPreProcessors() {
 		e.Put()
 		return
 	}

--- a/entry/entry.go
+++ b/entry/entry.go
@@ -163,12 +163,11 @@ func (e *LogEntry) logWithSkip(level enum.LogLevel, ctx context.Context, message
 		}
 	}
 
-	// why: reuse pooled buf instead of make([]byte, 0, 256) per call.
-	// The backing array was pre-grown to initBufCap (1 KB) at pool construction
-	// and is reset to len=0 (not nil) on each pool cycle, so no allocation
-	// occurs on the hot path for log lines that fit within the capacity.
-	// D-6 / F27 / ARCH-8.
-	e.buf = e.buf[:0]
+	// why: prepend the encoder's opening bytes (e.g. `{` for JSON) directly into
+	// e.buf instead of allocating a new buffer via Encoder.Append(nil, body).
+	// snap.EncoderOpen is pre-fetched in GetHotSnapshot (outside configMu) so
+	// this append performs zero locks. D-6 / F27 / ARCH-8 / Epic V2 P4.
+	e.buf = append(e.buf[:0], snap.EncoderOpen...)
 
 	// why: append the pre-rendered `"key":` prefix bytes directly instead of
 	// calling AppendField, which would re-encode the key string on every call.
@@ -228,12 +227,18 @@ func (e *LogEntry) logWithSkip(level enum.LogLevel, ctx context.Context, message
 		e.buf = append(e.buf, snap.StaticFields...)
 	}
 
-	// why: snap.Encoder.Append(nil, e.buf) allocates a fresh []byte for the
-	// encoded log line (wraps body in {…}\n). byteData does not share the
-	// backing array with e.buf, so it is safe to Put e immediately after
-	// (D-6 / ARCH-7 explicit-copy step).
-	byteData := snap.Encoder.Append(nil, e.buf)
-	config.PublishLog(level, byteData)
+	// why: append closing bytes (e.g. `}\n` for JSON) directly into e.buf —
+	// no intermediate allocation. Then transfer ownership of e.buf to the
+	// channel by severing the pool alias: replace e.buf with a fresh
+	// make([]byte, 0, initBufCap) so that reset() in e.Put() retains this
+	// new backing array (not the one handed to PublishLog). ProcessLogEvent
+	// reads Data asynchronously; after the transfer the pool goroutine and the
+	// consumer goroutine each own separate backing arrays — no data race.
+	// Eliminates 2 allocs per call vs pre-P4 (en.Append + dataCopy). P4.
+	e.buf = append(e.buf, snap.EncoderClose...)
+	data := e.buf
+	e.buf = make([]byte, 0, initBufCap)
+	config.PublishLog(level, data)
 	e.Put()
 }
 

--- a/entry/inline_framing_bench_test.go
+++ b/entry/inline_framing_bench_test.go
@@ -1,0 +1,43 @@
+package entry_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	pipelineStage "github.com/architagr/lognugget/pipeline_stage"
+)
+
+type inlineFramingWriter struct{}
+
+func (w *inlineFramingWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// BenchmarkLogEntry_InlineFraming_10 measures the hot path after P4 inline
+// framing: OpenBytes prepend + CloseBytes append + ownership transfer,
+// eliminating the en.Append intermediate buffer and the PublishLog defensive
+// copy. Target: allocs/op drops by ≥ 1 vs the P3 baseline.
+func BenchmarkLogEntry_InlineFraming_10(b *testing.B) {
+	b.StopTimer()
+	out := &inlineFramingWriter{}
+	config.SetMinLevel(enum.LevelDebug)
+	config.SetEncoderType(enum.EncoderJSON)
+	config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+		return append(dst, `,"k1":"v1","k2":"v2","k3":"v3","k4":"v4","k5":"v5","k6":"v6","k7":"v7","k8":"v8","k9":"v9","k10":"v10"`...)
+	})
+	unset := pipelineStage.NewUnsetLogEventPostProcessor(2*time.Second, 1000, out)
+	pipelineStage.EventPreProcessorObj.RegisterHook(enum.LevelUnSet, unset)
+	config.InitPreProcessors(pipelineStage.EventPreProcessorObj)
+	entry.GenerateInitialPool(10_000)
+	b.Cleanup(unset.Stop)
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		entry.NewLogEntry().Info(ctx, "bench p4")
+	}
+}

--- a/entry/inline_framing_test.go
+++ b/entry/inline_framing_test.go
@@ -1,0 +1,125 @@
+//go:build testing
+
+// Package entry_test: P4 inline-framing correctness tests.
+//
+// Tests verify that inline framing (OpenBytes prepend + CloseBytes append +
+// ownership transfer) produces byte-identical output to the pre-P4 approach,
+// and that the ownership transfer sequence is race-detector clean.
+package entry_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	"github.com/architagr/lognugget/test/support"
+)
+
+// drainInlineRec polls spy.Records() until at least n records arrive.
+func drainInlineRec(t *testing.T, spy *support.FakePreProc, n int) []support.FakePreProcRecord {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		recs := spy.Records()
+		if len(recs) >= n {
+			return recs
+		}
+		done := make(chan struct{})
+		go func() { close(done) }()
+		<-done
+	}
+	t.Fatalf("timed out: want %d records, got %d", n, len(spy.Records()))
+	return nil
+}
+
+// Test_InlineFraming_JSONOutput verifies that a full log call with the JSON
+// encoder produces a valid JSON object starting with '{' and ending with "}\n",
+// byte-identical to the pre-P4 Encoder.Append path.
+func Test_InlineFraming_JSONOutput(t *testing.T) {
+	support.NewConfigBuilder(t).
+		MinLevel(enum.LevelDebug).
+		Encoder(enum.EncoderJSON).
+		Build()
+	spy := support.NewFakePreProc("json-framing")
+	config.InitPreProcessors(spy)
+
+	entry.NewLogEntry().Info(context.Background(), "hello")
+
+	recs := drainInlineRec(t, spy, 1)
+	got := recs[0].Data
+
+	if !bytes.HasPrefix(got, []byte("{")) {
+		t.Errorf("JSON output must start with '{'; got: %q", got)
+	}
+	if !bytes.HasSuffix(got, []byte("}\n")) {
+		t.Errorf("JSON output must end with '}\\n'; got: %q", got)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(got, &obj); err != nil {
+		t.Errorf("JSON output must be valid JSON: %v\npayload: %s", err, got)
+	}
+	if obj["message"] != "hello" {
+		t.Errorf("JSON output must contain message=hello; got %v", obj["message"])
+	}
+}
+
+// Test_InlineFraming_TextOutput verifies that a full log call with the text
+// encoder produces output ending with '\n' (no double newline).
+func Test_InlineFraming_TextOutput(t *testing.T) {
+	support.NewConfigBuilder(t).
+		MinLevel(enum.LevelDebug).
+		Encoder(enum.EncoderText).
+		Build()
+	spy := support.NewFakePreProc("text-framing")
+	config.InitPreProcessors(spy)
+
+	entry.NewLogEntry().Info(context.Background(), "hello text")
+
+	recs := drainInlineRec(t, spy, 1)
+	got := recs[0].Data
+
+	if !bytes.HasSuffix(got, []byte("\n")) {
+		t.Errorf("text output must end with newline; got: %q", got)
+	}
+	if bytes.HasSuffix(got, []byte("\n\n")) {
+		t.Errorf("text output must not end with double newline; got: %q", got)
+	}
+}
+
+// Test_OwnershipTransfer_RaceClean fires concurrent log calls under the race
+// detector and asserts all events are delivered without a data race. After P4,
+// the entry's buf is transferred to the channel and severed with a fresh
+// make([]byte, 0, initBufCap) before e.Put() — this test verifies that
+// sequence is race-free.
+func Test_OwnershipTransfer_RaceClean(t *testing.T) {
+	const n = 50
+	support.NewConfigBuilder(t).
+		MinLevel(enum.LevelDebug).
+		Encoder(enum.EncoderJSON).
+		Build()
+	spy := support.NewFakePreProc("race-clean")
+	config.InitPreProcessors(spy)
+	entry.GenerateInitialPool(n)
+
+	var wg sync.WaitGroup
+	ctx := context.Background()
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			entry.NewLogEntry().Info(ctx, "race test")
+		}()
+	}
+	wg.Wait()
+
+	recs := drainInlineRec(t, spy, n)
+	if len(recs) < n {
+		t.Errorf("ownership transfer: want %d events delivered; got %d", n, len(recs))
+	}
+}


### PR DESCRIPTION
Fixes #85

## Summary

- Rewrite `logWithSkip` to prepend `snap.EncoderOpen` and append `snap.EncoderClose` directly into `e.buf` — no `en.Append(nil, e.buf)` intermediate buffer allocation
- Transfer ownership of `e.buf` to the channel: `data := e.buf; e.buf = make([]byte, 0, initBufCap)` before `e.Put()` — pool gets fresh backing array, channel gets the old one exclusively
- Remove `append([]byte(nil), Data...)` defensive copy from `PublishLog` — ownership transfer in `logWithSkip` makes it redundant
- Add `NoopFramer` embeddable struct to `encoder` package for third-party encoder implementations
- Update `config/publish_test.go` to reflect P4 ownership-transfer contract

## Alloc savings

- `en.Append(nil, e.buf)` → **-1 alloc/call**
- `append([]byte(nil), Data...)` in PublishLog → **-1 alloc/call**
- Fresh `make([]byte, 0, initBufCap)` in logWithSkip → **+1 alloc/call** (sever alias)
- Net: **-1 alloc/call** after this story alone; combined with P2+P3 the hot path approaches ≤ 5 allocs/op

## Note on bench gate
Individual story bench gate exits 1 — the 1000 ns/op target requires all 5 V2 stories combined. Gate will pass on `feat/81-v2-performance` after all branches merge.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>