### PR TITLE
docs(os4): godoc audit — all exported symbols documented

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,17 +26,23 @@ import (
 )
 
 var (
-	DafaultLevel       enum.LogLevel      = enum.LevelInfo   // Default log level
-	DafaultEncoderType enum.LogEncodeType = enum.EncoderJSON // Default encoder type
+	// DafaultLevel is the minimum log level applied when no explicit level has been set.
+	DafaultLevel enum.LogLevel = enum.LevelInfo
+	// DafaultEncoderType is the encoder format used when no explicit encoder has been set.
+	DafaultEncoderType enum.LogEncodeType = enum.EncoderJSON
 	// DefaultAddSource is the package default for whether source file/line
 	// information is appended to every log entry. It is false by design so
 	// that zero-config deployments do not pay the runtime.Callers overhead
 	// (D-7). Callers may opt in explicitly via config.SetAddSource(true).
-	DefaultAddSource  bool      = false
-	DefaultOutput     io.Writer = os.Stdout    // Default output writer
-	DefaultTimeFormat string    = time.RFC3339 // Default time format for log entries
-	DafaultLogBuffer  int       = 1000         // Default buffer size for logs
-	DefaultPrefix     string    = "custom."
+	DefaultAddSource bool = false
+	// DefaultOutput is the writer used for log output when none has been configured.
+	DefaultOutput io.Writer = os.Stdout
+	// DefaultTimeFormat is the time layout applied to log entry timestamps when none has been configured.
+	DefaultTimeFormat string = time.RFC3339
+	// DafaultLogBuffer is the default channel buffer size for the log dispatch pipeline.
+	DafaultLogBuffer int = 1000
+	// DefaultPrefix is prepended to user-supplied field keys that collide with reserved log keys.
+	DefaultPrefix string = "custom."
 )
 
 // atomicMinLevel mirrors defaultConfig.minLevel as an atomic.Int64 so that
@@ -167,17 +173,30 @@ func GetHotSnapshot() HotSnapshot {
 	return snap
 }
 
+// PublishLogMessageHookContract is the interface that log-level hooks must
+// implement. Hooks are registered via RegisterHook and called by the pre-processor
+// fan-out stage for every matching log event.
 type PublishLogMessageHookContract interface {
 	PublishLogMessage(entry []byte)
 	Name() string
 }
+
+// StaticEnvFieldsParser is a function that returns a map of static fields
+// to be merged into every log line at startup. Pass it to SetStaticEnvFieldsParser.
 type StaticEnvFieldsParser = func() map[string]any
+
+// ContextFieldsParser is the legacy per-request context field extractor.
+// It receives a context and returns a map of fields to merge into the log line.
+// Prefer ContextFieldsAppender for zero-allocation hot paths.
 type ContextFieldsParser = func(ctx context.Context) map[string]any
 
 func init() {
 	resetConfig()
 }
 
+// Config holds the active logger configuration. All fields are guarded by
+// configMu; use the exported Set* mutators and Get* accessors rather than
+// reading or writing fields directly.
 type Config struct {
 	minLevel              enum.LogLevel                      // Minimum log level to log
 	encoderType           enum.LogEncodeType                 // Encoder type to use for logging
@@ -195,6 +214,9 @@ type Config struct {
 	hooks                 map[enum.LogLevel]map[string]PublishLogMessageHookContract
 }
 
+// LogEvent is a single serialised log message dispatched through the pipeline.
+// Level is used by pre-processors to route the event to matching hooks;
+// Data holds the fully encoded log line (e.g. a JSON object with a trailing newline).
 type LogEvent struct {
 	Level enum.LogLevel
 	Data  []byte

--- a/enum/default_log_key.go
+++ b/enum/default_log_key.go
@@ -1,57 +1,91 @@
 package enum
 
+// DefaultLogKey is the string key type for the standard fields written into
+// every log entry. Pass these constants to config.SetDefaultFields to rename
+// a core field, or use them as map keys when reading config.DefaultFields.
 type DefaultLogKey string
 
-// DefaultLogKey represents the default keys used in log entries.
-// These keys are used to standardize the fields in log entries for consistency.
-// They can be used to set default fields in the logger configuration.
-// The keys are used to identify specific attributes in log entries, such as time, level, message, error, etc.
-// The keys are defined as constants for easy reference and to avoid typos.
-// The keys can be used in conjunction with the LogAttr struct to create structured log entries.
-// The keys can be used to set default fields in the logger configuration.
-// The keys can be used to extract static fields from the environment.
-// The keys can be used to extract context fields from the context.
-// The keys can be used to set default fields in the logger configuration.
 const (
-	DefaultLogKeyTime          DefaultLogKey = "time"
-	DefaultLogKeyLevel         DefaultLogKey = "level"
-	DefaultLogKeyMessage       DefaultLogKey = "message"
-	DefaultLogKeyError         DefaultLogKey = "error"
-	DefaultLogKeyCaller        DefaultLogKey = "caller"
-	DefaultLogKeyContext       DefaultLogKey = "context"
-	DefaultLogKeyDuration      DefaultLogKey = "duration"
-	DefaultLogKeyFields        DefaultLogKey = "fields"
-	DefaultLogKeySource        DefaultLogKey = "source"
-	DefaultLogKeyStatic        DefaultLogKey = "static"
-	DefaultLogKeyEnv           DefaultLogKey = "env"
-	DefaultLogKeyHost          DefaultLogKey = "host"
-	DefaultLogKeyService       DefaultLogKey = "service"
-	DefaultLogKeyVersion       DefaultLogKey = "version"
-	DefaultLogKeyRequest       DefaultLogKey = "request"
-	DefaultLogKeyResponse      DefaultLogKey = "response"
-	DefaultLogKeyUser          DefaultLogKey = "user"
-	DefaultLogKeySession       DefaultLogKey = "session"
-	DefaultLogKeyTraceID       DefaultLogKey = "trace_id"
-	DefaultLogKeySpanID        DefaultLogKey = "span_id"
+	// DefaultLogKeyTime is the key for the log entry timestamp field.
+	DefaultLogKeyTime DefaultLogKey = "time"
+	// DefaultLogKeyLevel is the key for the severity level field.
+	DefaultLogKeyLevel DefaultLogKey = "level"
+	// DefaultLogKeyMessage is the key for the human-readable log message field.
+	DefaultLogKeyMessage DefaultLogKey = "message"
+	// DefaultLogKeyError is the key for the error string field.
+	DefaultLogKeyError DefaultLogKey = "error"
+	// DefaultLogKeyCaller is the key for the call-site function name field.
+	DefaultLogKeyCaller DefaultLogKey = "caller"
+	// DefaultLogKeyContext is the key for per-request context fields.
+	DefaultLogKeyContext DefaultLogKey = "context"
+	// DefaultLogKeyDuration is the key for an operation duration field.
+	DefaultLogKeyDuration DefaultLogKey = "duration"
+	// DefaultLogKeyFields is the key for an arbitrary extra-fields container.
+	DefaultLogKeyFields DefaultLogKey = "fields"
+	// DefaultLogKeySource is the key for the originating source identifier field.
+	DefaultLogKeySource DefaultLogKey = "source"
+	// DefaultLogKeyStatic is the key for static environment fields baked in at startup.
+	DefaultLogKeyStatic DefaultLogKey = "static"
+	// DefaultLogKeyEnv is the key for the deployment environment label (e.g. "prod").
+	DefaultLogKeyEnv DefaultLogKey = "env"
+	// DefaultLogKeyHost is the key for the hostname field.
+	DefaultLogKeyHost DefaultLogKey = "host"
+	// DefaultLogKeyService is the key for the service name field.
+	DefaultLogKeyService DefaultLogKey = "service"
+	// DefaultLogKeyVersion is the key for the application version field.
+	DefaultLogKeyVersion DefaultLogKey = "version"
+	// DefaultLogKeyRequest is the key for a request payload or identifier field.
+	DefaultLogKeyRequest DefaultLogKey = "request"
+	// DefaultLogKeyResponse is the key for a response payload or identifier field.
+	DefaultLogKeyResponse DefaultLogKey = "response"
+	// DefaultLogKeyUser is the key for the acting user identifier field.
+	DefaultLogKeyUser DefaultLogKey = "user"
+	// DefaultLogKeySession is the key for the session identifier field.
+	DefaultLogKeySession DefaultLogKey = "session"
+	// DefaultLogKeyTraceID is the key for the distributed-tracing trace ID field.
+	DefaultLogKeyTraceID DefaultLogKey = "trace_id"
+	// DefaultLogKeySpanID is the key for the distributed-tracing span ID field.
+	DefaultLogKeySpanID DefaultLogKey = "span_id"
+	// DefaultLogKeyCorrelationID is the key for a cross-service correlation ID field.
 	DefaultLogKeyCorrelationID DefaultLogKey = "correlation_id"
-	DefaultLogKeyComponent     DefaultLogKey = "component"
-	DefaultLogKeyOperation     DefaultLogKey = "operation"
-	DefaultLogKeyStatus        DefaultLogKey = "status"
-	DefaultLogKeyLatency       DefaultLogKey = "latency"
-	DefaultLogKeyRequestID     DefaultLogKey = "request_id"
-	DefaultLogKeyResponseTime  DefaultLogKey = "response_time"
-	DefaultLogKeyClientIP      DefaultLogKey = "client_ip"
-	DefaultLogKeyServerIP      DefaultLogKey = "server_ip"
-	DefaultLogKeyProtocol      DefaultLogKey = "protocol"
-	DefaultLogKeyMethod        DefaultLogKey = "method"
-	DefaultLogKeyURL           DefaultLogKey = "url"
-	DefaultLogKeyStatusCode    DefaultLogKey = "status_code"
-	DefaultLogKeyContentType   DefaultLogKey = "content_type"
+	// DefaultLogKeyComponent is the key for the logical component or module name field.
+	DefaultLogKeyComponent DefaultLogKey = "component"
+	// DefaultLogKeyOperation is the key for the operation or action name field.
+	DefaultLogKeyOperation DefaultLogKey = "operation"
+	// DefaultLogKeyStatus is the key for an operation status descriptor field.
+	DefaultLogKeyStatus DefaultLogKey = "status"
+	// DefaultLogKeyLatency is the key for the request latency measurement field.
+	DefaultLogKeyLatency DefaultLogKey = "latency"
+	// DefaultLogKeyRequestID is the key for a unique request identifier field.
+	DefaultLogKeyRequestID DefaultLogKey = "request_id"
+	// DefaultLogKeyResponseTime is the key for the total response time field.
+	DefaultLogKeyResponseTime DefaultLogKey = "response_time"
+	// DefaultLogKeyClientIP is the key for the client IP address field.
+	DefaultLogKeyClientIP DefaultLogKey = "client_ip"
+	// DefaultLogKeyServerIP is the key for the server IP address field.
+	DefaultLogKeyServerIP DefaultLogKey = "server_ip"
+	// DefaultLogKeyProtocol is the key for the network protocol field (e.g. "HTTP/1.1").
+	DefaultLogKeyProtocol DefaultLogKey = "protocol"
+	// DefaultLogKeyMethod is the key for the HTTP (or RPC) method field.
+	DefaultLogKeyMethod DefaultLogKey = "method"
+	// DefaultLogKeyURL is the key for the request URL field.
+	DefaultLogKeyURL DefaultLogKey = "url"
+	// DefaultLogKeyStatusCode is the key for the HTTP response status code field.
+	DefaultLogKeyStatusCode DefaultLogKey = "status_code"
+	// DefaultLogKeyContentType is the key for the Content-Type header field.
+	DefaultLogKeyContentType DefaultLogKey = "content_type"
+	// DefaultLogKeyContentLength is the key for the Content-Length header field.
 	DefaultLogKeyContentLength DefaultLogKey = "content_length"
-	DefaultLogKeyResponseSize  DefaultLogKey = "response_size"
-	DefaultLogKeyRequestSize   DefaultLogKey = "request_size"
-	DefaultLogKeyUserAgent     DefaultLogKey = "user_agent"
-	DefaultLogKeyReferer       DefaultLogKey = "referer"
-	DefaultLogKeyForwardedFor  DefaultLogKey = "forwarded_for"
-	DefaultLogKeyCustom        DefaultLogKey = "custom"
+	// DefaultLogKeyResponseSize is the key for the response body size in bytes field.
+	DefaultLogKeyResponseSize DefaultLogKey = "response_size"
+	// DefaultLogKeyRequestSize is the key for the request body size in bytes field.
+	DefaultLogKeyRequestSize DefaultLogKey = "request_size"
+	// DefaultLogKeyUserAgent is the key for the User-Agent header field.
+	DefaultLogKeyUserAgent DefaultLogKey = "user_agent"
+	// DefaultLogKeyReferer is the key for the Referer header field.
+	DefaultLogKeyReferer DefaultLogKey = "referer"
+	// DefaultLogKeyForwardedFor is the key for the X-Forwarded-For header field.
+	DefaultLogKeyForwardedFor DefaultLogKey = "forwarded_for"
+	// DefaultLogKeyCustom is the key for user-defined custom metadata fields.
+	DefaultLogKeyCustom DefaultLogKey = "custom"
 )

--- a/enum/level.go
+++ b/enum/level.go
@@ -4,14 +4,23 @@ import (
 	"fmt"
 )
 
+// LogLevel is a numeric severity level used to filter and label log entries.
+// Higher values are more severe. Use the named constants (LevelDebug through
+// LevelFatal) rather than raw integers.
 type LogLevel int
 
 const (
+	// LevelUnSet is the zero-config catch-all level that matches every log event.
 	LevelUnSet LogLevel = 1 << iota
+	// LevelDebug is the lowest named severity, intended for verbose diagnostic output.
 	LevelDebug LogLevel = 1 << iota
-	LevelInfo  LogLevel = 1 << iota
-	LevelWarn  LogLevel = 1 << iota
+	// LevelInfo is the standard informational severity for routine operational messages.
+	LevelInfo LogLevel = 1 << iota
+	// LevelWarn indicates a recoverable condition that may warrant attention.
+	LevelWarn LogLevel = 1 << iota
+	// LevelError indicates a failure that has been handled but should be investigated.
 	LevelError LogLevel = 1 << iota
+	// LevelFatal is the highest named severity; callers typically exit after logging at this level.
 	LevelFatal LogLevel = 1 << iota
 )
 

--- a/enum/log_encode_type.go
+++ b/enum/log_encode_type.go
@@ -1,8 +1,12 @@
 package enum
 
+// LogEncodeType identifies the wire format used to serialise log entries.
+// Pass it to config.SetEncoderType to switch the active encoder.
 type LogEncodeType string
 
 const (
+	// EncoderJSON serialises log entries as single-line JSON objects.
 	EncoderJSON LogEncodeType = "json"
+	// EncoderText serialises log entries as plain text lines without JSON framing.
 	EncoderText LogEncodeType = "text"
 )


### PR DESCRIPTION
Adds missing godoc comments to all exported types, functions, methods, consts, and vars. No logic changes.

Files changed: enum/level.go, enum/log_encode_type.go, enum/default_log_key.go, config/config.go.

Refs #91