### PR TITLE
docs(epic-os): open-source readiness — CONTRIBUTING, CoC, CI, godoc, CHANGELOG, SECURITY

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: Report a reproducible bug in LogNugget
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal code or steps that trigger the bug.
+      placeholder: |
+        entry := entry.NewLogEntry()
+        entry.Info(ctx, "msg")
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+    validations:
+      required: true
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version
+      placeholder: "go1.21.0"
+    validations:
+      required: true
+  - type: input
+    id: lognugget-version
+    attributes:
+      label: LogNugget version or commit
+      placeholder: "v2.0.0"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Propose a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this solve? What use case drives it?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to see added or changed.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you evaluated and why you ruled them out.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+- 
+- 
+
+## Issue
+
+Fixes #
+
+## Test plan
+
+- [ ] Describe how you tested the change
+
+## Checklist
+
+- [ ] `go test ./... -tags testing -race -shuffle=on` passes
+- [ ] `golangci-lint run` is clean
+- [ ] `./scripts/bench-check.sh` is green (for hot-path changes)
+- [ ] New exported symbols have godoc comments
+- [ ] Issue number referenced above

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout=5m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,11 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     branches:
       - main
+      - develop
 
 name: All builds
 jobs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+version: "2"
+linters:
+  enable:
+    - gofmt
+    - govet
+    - staticcheck
+    - gosimple
+    - ineffassign
+    - unused
+    - errcheck
+    - bodyclose
+    - noctx
+    - godot
+  disable:
+    - depguard
+linters-settings:
+  godot:
+    scope: declarations
+    capital: false
+run:
+  timeout: 5m
+  tests: false
+issues:
+  exclude-rules:
+    - path: "_test.go"
+      linters:
+        - errcheck
+    - path: "test_only_helpers.go"
+      linters:
+        - unused

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog
+
+All notable changes to LogNugget will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+---
+
+## [2.0.0] - 2026-05-22
+
+### Added
+
+- **Typed chain methods** on `LogEntry`: `Str`, `Int`, `Uint`, `Float64`, `Bool` — eliminates interface boxing for the five most common field types (Epic V2 P2).
+- **`config.SetChannelCapacity(n)`** — caller-configurable async channel depth (default 1000) (Epic V2 P5).
+- **`config.ContextFieldsAppender` type** — zero-alloc context-field API; replaces `map[string]any` returned by `ContextFieldsParser` (Epic V2 P3).
+- **`config.HasEventPreProcessors()`** — predicate to check whether any pre-processors are registered before entering the publish path.
+- **`HotSnapshot`** — single config snapshot captured once per `LogEntry.Info/Warn/Error/Debug` call, replacing per-field config reads (Epic V2 P1).
+
+### Changed
+
+- **`config.SetContextFieldsParser`** now accepts `config.ContextFieldsAppender` instead of `func(context.Context) map[string]any`. Callers that use the old signature must migrate to the appender API. See migration notes below.
+- **Inline encoder framing + ownership transfer** — encoder now writes directly into the entry buffer with no intermediate double-buffer copy (Epic V2 P4).
+- **Minimum level gate** is now an atomic `int32` load (`atomic.LoadInt32`) instead of a mutex-protected read; filtered calls cost ~10 ns, 0 allocs (Epic V2 P1).
+- **Async channel capacity** increased from 10 → 1000 (configurable via `config.SetChannelCapacity`) (Epic V2 P5).
+- Internal package `pipeline_stage` is not part of the stable public API; callers should not import it directly.
+
+### Performance
+
+Measured on Apple M1 Pro (`go test -bench=. -benchmem -count=10 -run=^$ ./...`):
+
+| Path | v1.0.0 | v2.0.0 | Delta |
+|------|--------|--------|-------|
+| Serial (no ctx fields) | ~3,630 ns/op, 55 allocs | ~1,280 ns/op, 6 allocs | −65% latency, −91% allocs |
+| Parallel 8-core (no ctx fields) | ~3,440 ns/op, 55 allocs | ~1,090 ns/op, 5 allocs | −68% latency, −91% allocs |
+| Filtered (below min level) | — | ~10 ns/op, 0 allocs | new fast-reject path |
+| Per-field `Str` encode | — | ~25 ns/op, 0 allocs | new typed path |
+| Per-field `Int` encode | — | ~11 ns/op, 0 allocs | new typed path |
+
+#### Migration notes (v1 → v2)
+
+The only breaking change is `config.SetContextFieldsParser`. Replace:
+
+```go
+// v1
+config.SetContextFieldsParser(func(ctx context.Context) map[string]any {
+    return map[string]any{"trace_id": extractTraceID(ctx)}
+})
+```
+
+with:
+
+```go
+// v2
+config.SetContextFieldsParser(func(ctx context.Context, appender config.ContextFieldsAppender) {
+    appender.AppendString("trace_id", extractTraceID(ctx))
+})
+```
+
+All other v1 call sites are source-compatible with v2.
+
+---
+
+## [1.0.0] - 2026-05-21
+
+### Added
+
+- **First stable release** — 40 stories across Epics A–E landed on `main`.
+- **`sync.Pool`-backed `LogEntry`** — backing `[]byte` capacity preserved across pool cycles; zero per-call allocation on the hot path (Epic C alloc discipline).
+- **RFC 8259 JSON escaping** — all string field values escaped per spec; no log-injection via crafted field values (Epic B behavior gaps).
+- **Context-fields parser** (`config.SetContextFieldsParser`) — per-call `map[string]any` propagating trace/span/request IDs from `context.Context` (Epic B).
+- **`lognugget.Shutdown()`** — blocks until all buffered events are flushed; safe to `defer` in `main()` or a signal handler (Epic D lifecycle).
+- **Zero-config init** — importing `_ "github.com/architagr/lognugget/lognugget"` starts the async pipeline with sensible defaults; no `NewLogger()` required.
+- **Static env fields parser** (`config.SetStaticEnvFieldsParser`) — once-evaluated fields (hostname, service name) injected into every log line.
+- **`pipeline_stage.Stop()`** — graceful per-stage shutdown separating drain from teardown (Epic D).
+- **Full test suite** — table-driven tests + race-detector runs for all public APIs; codecov gating on CI (Epic A test hygiene).
+- **Encoder abstraction** — `encoder.Encoder` interface with `NewJSONEncoder` and `NewTextEncoder` implementations (Epic B).
+- **`model.LogAttr` + typed constructors** — `StringAttr`, `IntAttr`, `BoolAttr`, `Float64Attr` convenience constructors (Epic B).
+- **M3 baseline** — serial ~2,050 ns/op, 18 allocs/op; bench-check gate enforced at < 1 µs on filtered path.
+- **`config.SetLogBufferMaxSize`**, **`config.SetRate`**, **`config.SetTimeFormat`**, **`config.SetAddSource`** — full configuration surface.
+- **Fan-out hooks** — `pipeline_stage.NewUnsetLogEventPostProcessor` + `RegisterHook` for secondary sinks (Loki, Datadog, file) (Epic B).
+
+---
+
+[Unreleased]: https://github.com/architagr/LogNugget/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/architagr/LogNugget/compare/v1.0.0...v2.0.0
+[1.0.0]: https://github.com/architagr/LogNugget/releases/tag/v1.0.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct.
+
+All contributors are expected to uphold this standard. Instances of unacceptable behaviour may be reported to the project maintainer at **architagr@gmail.com**. All complaints will be reviewed and investigated promptly and fairly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to LogNugget
+
+Thank you for contributing! Please read this guide before opening issues or pull requests.
+
+## Prerequisites
+
+- Go 1.21+
+- [`golangci-lint`](https://golangci-lint.run/usage/install/) installed and on your `$PATH`
+
+## Workflow
+
+1. **Fork** the repository and clone your fork locally.
+2. **Branch** off `develop` using the naming convention below.
+3. **Implement** with TDD — write tests first, then make them pass.
+4. **Open a draft PR** as soon as local tests pass; this is the surface QA reviews against.
+5. **Address QA** comments (up to 3 cycles); unresolved threads are arbitrated by the Project Lead.
+6. **Mark ready** only after all gates below are green.
+
+## Branch Naming
+
+```
+feat/<issue>-<short-slug>     # new feature
+fix/<issue>-<short-slug>      # bug fix
+docs/<issue>-<short-slug>     # documentation only
+chore/<issue>-<short-slug>    # tooling, deps, config
+refactor/<issue>-<short-slug> # code restructure without behaviour change
+perf/<issue>-<short-slug>     # performance improvement
+```
+
+All branches are cut from `develop` and PR back to `develop` (or the parent feature branch for sub-tasks).
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat(encoder): add JSON pretty-print option (refs #42)
+fix(pipeline): prevent nil-deref on empty stage list (fixes #57)
+docs: update README with Redis backend example
+perf(lru): reduce allocations in hot path (refs #61)
+```
+
+Types: `feat`, `fix`, `docs`, `chore`, `perf`, `refactor`, `test`.
+
+## Running Tests
+
+```bash
+go test ./... -tags testing -race -shuffle=on
+```
+
+## Running the Linter
+
+```bash
+golangci-lint run
+```
+
+## Performance Gate
+
+Every change to a hot path must include a `*_bench_test.go` file. Run the gate before marking a PR ready:
+
+```bash
+./scripts/bench-check.sh
+```
+
+The gate fails if any benchmark mean exceeds **1 µs (1,000 ns/op)** or introduces a statistically significant regression against `bench-baseline.txt`. Bypassing the gate is not permitted.
+
+## PR Checklist
+
+Before marking a draft PR as ready for review, confirm:
+
+- [ ] `go test ./... -tags testing -race -shuffle=on` passes
+- [ ] `golangci-lint run` is clean
+- [ ] `./scripts/bench-check.sh` is green
+- [ ] The PR body references the related issue (`Fixes #<n>`)
+- [ ] New public APIs are documented with Go doc comments

--- a/README.md
+++ b/README.md
@@ -222,6 +222,20 @@ All benchmarks from `go test -bench=. -benchmem -count=10 -run=^$ ./...` on Appl
 
 ---
 
+## API Stability
+
+LogNugget follows [Semantic Versioning](https://semver.org/):
+
+- **Patch** (v2.0.x): bug fixes, no API changes.
+- **Minor** (v2.x.0): backward-compatible additions. Existing callers need no changes.
+- **Major** (v3.0.0): breaking changes announced in [CHANGELOG.md](CHANGELOG.md) with migration notes.
+
+The public API surface is: `package lognugget` (Shutdown), `package entry` (NewLogEntry, LogEntry methods), `package config` (all Set* functions, ContextFieldsAppender), `package encoder` (Encoder interface, NewJSONEncoder, NewTextEncoder), `package model` (LogAttr, typed constructors), `package enum` (LogLevel, LogEncodeType, DefaultLogKey constants).
+
+Internal packages (`pipeline_stage`, `custom_time`) are not stable API — callers should not import them directly.
+
+---
+
 ## Hooks Support
 
 LogNugget supports hooks for fan-out to external systems:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-LogNugget is currently pre-1.0. Security fixes are accepted for the active `v1.x` development line and the latest release/tag published from it.
+Supported versions: **v1.x** and **v2.x** (latest tag on `main`). Security fixes are accepted for both active lines.
 
 ## Reporting a Vulnerability
 
@@ -14,7 +14,7 @@ Use GitHub's private vulnerability reporting flow instead:
 2. Choose **Report a vulnerability**.
 3. Include the details listed below.
 
-If private vulnerability reporting is not yet visible, contact a maintainer listed in `MAINTAINERS.md` and ask for a private reporting channel before sharing exploit details.
+If private vulnerability reporting is not yet visible, email the maintainer at architagr@gmail.com and ask for a private reporting channel before sharing exploit details.
 
 ## What to Include
 

--- a/config/config.go
+++ b/config/config.go
@@ -26,17 +26,23 @@ import (
 )
 
 var (
-	DafaultLevel       enum.LogLevel      = enum.LevelInfo   // Default log level
-	DafaultEncoderType enum.LogEncodeType = enum.EncoderJSON // Default encoder type
+	// DafaultLevel is the minimum log level applied when no explicit level has been set.
+	DafaultLevel enum.LogLevel = enum.LevelInfo
+	// DafaultEncoderType is the encoder format used when no explicit encoder has been set.
+	DafaultEncoderType enum.LogEncodeType = enum.EncoderJSON
 	// DefaultAddSource is the package default for whether source file/line
 	// information is appended to every log entry. It is false by design so
 	// that zero-config deployments do not pay the runtime.Callers overhead
 	// (D-7). Callers may opt in explicitly via config.SetAddSource(true).
-	DefaultAddSource  bool      = false
-	DefaultOutput     io.Writer = os.Stdout    // Default output writer
-	DefaultTimeFormat string    = time.RFC3339 // Default time format for log entries
-	DafaultLogBuffer  int       = 1000         // Default buffer size for logs
-	DefaultPrefix     string    = "custom."
+	DefaultAddSource bool = false
+	// DefaultOutput is the writer used for log output when none has been configured.
+	DefaultOutput io.Writer = os.Stdout
+	// DefaultTimeFormat is the time layout applied to log entry timestamps when none has been configured.
+	DefaultTimeFormat string = time.RFC3339
+	// DafaultLogBuffer is the default channel buffer size for the log dispatch pipeline.
+	DafaultLogBuffer int = 1000
+	// DefaultPrefix is prepended to user-supplied field keys that collide with reserved log keys.
+	DefaultPrefix string = "custom."
 )
 
 // atomicMinLevel mirrors defaultConfig.minLevel as an atomic.Int64 so that
@@ -167,17 +173,30 @@ func GetHotSnapshot() HotSnapshot {
 	return snap
 }
 
+// PublishLogMessageHookContract is the interface that log-level hooks must
+// implement. Hooks are registered via RegisterHook and called by the pre-processor
+// fan-out stage for every matching log event.
 type PublishLogMessageHookContract interface {
 	PublishLogMessage(entry []byte)
 	Name() string
 }
+
+// StaticEnvFieldsParser is a function that returns a map of static fields
+// to be merged into every log line at startup. Pass it to SetStaticEnvFieldsParser.
 type StaticEnvFieldsParser = func() map[string]any
+
+// ContextFieldsParser is the legacy per-request context field extractor.
+// It receives a context and returns a map of fields to merge into the log line.
+// Prefer ContextFieldsAppender for zero-allocation hot paths.
 type ContextFieldsParser = func(ctx context.Context) map[string]any
 
 func init() {
 	resetConfig()
 }
 
+// Config holds the active logger configuration. All fields are guarded by
+// configMu; use the exported Set* mutators and Get* accessors rather than
+// reading or writing fields directly.
 type Config struct {
 	minLevel              enum.LogLevel                      // Minimum log level to log
 	encoderType           enum.LogEncodeType                 // Encoder type to use for logging
@@ -195,6 +214,9 @@ type Config struct {
 	hooks                 map[enum.LogLevel]map[string]PublishLogMessageHookContract
 }
 
+// LogEvent is a single serialised log message dispatched through the pipeline.
+// Level is used by pre-processors to route the event to matching hooks;
+// Data holds the fully encoded log line (e.g. a JSON object with a trailing newline).
 type LogEvent struct {
 	Level enum.LogLevel
 	Data  []byte

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # LogNugget — Live Status Dashboard
 
-> **Last updated:** 2026-05-22
+> **Last updated:** 2026-05-22 (Epic OS complete)
 > **v1.0.0:** Released ✅ — [tag v1.0.0](https://github.com/architagr/LogNugget/releases/tag/v1.0.0) · [PR #80](https://github.com/architagr/LogNugget/pull/80) (merged)
 > **Umbrella:** [#12](https://github.com/architagr/LogNugget/issues/12)
 
@@ -272,15 +272,15 @@ SLO miss (hot-path 2× over 1 µs) does NOT block v1.0.0 per project decision �
 ## Epic OS — Open Source Readiness
 
 > **Umbrella:** [#87](https://github.com/architagr/LogNugget/issues/87)
-> **Status:** 📋 PLANNED (post-v1.0.0)
+> **Status:** ✅ DONE — all OS1–OS5 merged, feat/87 → develop
 
 | # | Issue | Story | Status |
 |---|-------|-------|--------|
-| OS1 | [#88](https://github.com/architagr/LogNugget/issues/88) | CONTRIBUTING.md + PR/issue templates + CoC | 📋 PLANNED |
-| OS2 | [#89](https://github.com/architagr/LogNugget/issues/89) | SECURITY.md + vulnerability reporting | 📋 PLANNED |
-| OS3 | [#90](https://github.com/architagr/LogNugget/issues/90) | golangci-lint config + GitHub Actions CI | 📋 PLANNED |
-| OS4 | [#91](https://github.com/architagr/LogNugget/issues/91) | godoc audit — all exported symbols documented | 📋 PLANNED |
-| OS5 | [#92](https://github.com/architagr/LogNugget/issues/92) | API stability contract + CHANGELOG | 📋 PLANNED |
+| OS1 | [#88](https://github.com/architagr/LogNugget/issues/88) | CONTRIBUTING.md + PR/issue templates + CoC | ✅ DONE (PR [#103](https://github.com/architagr/LogNugget/pull/103)) |
+| OS2 | [#89](https://github.com/architagr/LogNugget/issues/89) | SECURITY.md + vulnerability reporting | ✅ DONE (PR [#100](https://github.com/architagr/LogNugget/pull/100)) |
+| OS3 | [#90](https://github.com/architagr/LogNugget/issues/90) | golangci-lint config + GitHub Actions CI | ✅ DONE (PR [#101](https://github.com/architagr/LogNugget/pull/101)) |
+| OS4 | [#91](https://github.com/architagr/LogNugget/issues/91) | godoc audit — all exported symbols documented | ✅ DONE (PR [#104](https://github.com/architagr/LogNugget/pull/104)) |
+| OS5 | [#92](https://github.com/architagr/LogNugget/issues/92) | API stability contract + CHANGELOG | ✅ DONE (PR [#102](https://github.com/architagr/LogNugget/pull/102)) |
 
 ---
 

--- a/enum/default_log_key.go
+++ b/enum/default_log_key.go
@@ -1,57 +1,91 @@
 package enum
 
+// DefaultLogKey is the string key type for the standard fields written into
+// every log entry. Pass these constants to config.SetDefaultFields to rename
+// a core field, or use them as map keys when reading config.DefaultFields.
 type DefaultLogKey string
 
-// DefaultLogKey represents the default keys used in log entries.
-// These keys are used to standardize the fields in log entries for consistency.
-// They can be used to set default fields in the logger configuration.
-// The keys are used to identify specific attributes in log entries, such as time, level, message, error, etc.
-// The keys are defined as constants for easy reference and to avoid typos.
-// The keys can be used in conjunction with the LogAttr struct to create structured log entries.
-// The keys can be used to set default fields in the logger configuration.
-// The keys can be used to extract static fields from the environment.
-// The keys can be used to extract context fields from the context.
-// The keys can be used to set default fields in the logger configuration.
 const (
-	DefaultLogKeyTime          DefaultLogKey = "time"
-	DefaultLogKeyLevel         DefaultLogKey = "level"
-	DefaultLogKeyMessage       DefaultLogKey = "message"
-	DefaultLogKeyError         DefaultLogKey = "error"
-	DefaultLogKeyCaller        DefaultLogKey = "caller"
-	DefaultLogKeyContext       DefaultLogKey = "context"
-	DefaultLogKeyDuration      DefaultLogKey = "duration"
-	DefaultLogKeyFields        DefaultLogKey = "fields"
-	DefaultLogKeySource        DefaultLogKey = "source"
-	DefaultLogKeyStatic        DefaultLogKey = "static"
-	DefaultLogKeyEnv           DefaultLogKey = "env"
-	DefaultLogKeyHost          DefaultLogKey = "host"
-	DefaultLogKeyService       DefaultLogKey = "service"
-	DefaultLogKeyVersion       DefaultLogKey = "version"
-	DefaultLogKeyRequest       DefaultLogKey = "request"
-	DefaultLogKeyResponse      DefaultLogKey = "response"
-	DefaultLogKeyUser          DefaultLogKey = "user"
-	DefaultLogKeySession       DefaultLogKey = "session"
-	DefaultLogKeyTraceID       DefaultLogKey = "trace_id"
-	DefaultLogKeySpanID        DefaultLogKey = "span_id"
+	// DefaultLogKeyTime is the key for the log entry timestamp field.
+	DefaultLogKeyTime DefaultLogKey = "time"
+	// DefaultLogKeyLevel is the key for the severity level field.
+	DefaultLogKeyLevel DefaultLogKey = "level"
+	// DefaultLogKeyMessage is the key for the human-readable log message field.
+	DefaultLogKeyMessage DefaultLogKey = "message"
+	// DefaultLogKeyError is the key for the error string field.
+	DefaultLogKeyError DefaultLogKey = "error"
+	// DefaultLogKeyCaller is the key for the call-site function name field.
+	DefaultLogKeyCaller DefaultLogKey = "caller"
+	// DefaultLogKeyContext is the key for per-request context fields.
+	DefaultLogKeyContext DefaultLogKey = "context"
+	// DefaultLogKeyDuration is the key for an operation duration field.
+	DefaultLogKeyDuration DefaultLogKey = "duration"
+	// DefaultLogKeyFields is the key for an arbitrary extra-fields container.
+	DefaultLogKeyFields DefaultLogKey = "fields"
+	// DefaultLogKeySource is the key for the originating source identifier field.
+	DefaultLogKeySource DefaultLogKey = "source"
+	// DefaultLogKeyStatic is the key for static environment fields baked in at startup.
+	DefaultLogKeyStatic DefaultLogKey = "static"
+	// DefaultLogKeyEnv is the key for the deployment environment label (e.g. "prod").
+	DefaultLogKeyEnv DefaultLogKey = "env"
+	// DefaultLogKeyHost is the key for the hostname field.
+	DefaultLogKeyHost DefaultLogKey = "host"
+	// DefaultLogKeyService is the key for the service name field.
+	DefaultLogKeyService DefaultLogKey = "service"
+	// DefaultLogKeyVersion is the key for the application version field.
+	DefaultLogKeyVersion DefaultLogKey = "version"
+	// DefaultLogKeyRequest is the key for a request payload or identifier field.
+	DefaultLogKeyRequest DefaultLogKey = "request"
+	// DefaultLogKeyResponse is the key for a response payload or identifier field.
+	DefaultLogKeyResponse DefaultLogKey = "response"
+	// DefaultLogKeyUser is the key for the acting user identifier field.
+	DefaultLogKeyUser DefaultLogKey = "user"
+	// DefaultLogKeySession is the key for the session identifier field.
+	DefaultLogKeySession DefaultLogKey = "session"
+	// DefaultLogKeyTraceID is the key for the distributed-tracing trace ID field.
+	DefaultLogKeyTraceID DefaultLogKey = "trace_id"
+	// DefaultLogKeySpanID is the key for the distributed-tracing span ID field.
+	DefaultLogKeySpanID DefaultLogKey = "span_id"
+	// DefaultLogKeyCorrelationID is the key for a cross-service correlation ID field.
 	DefaultLogKeyCorrelationID DefaultLogKey = "correlation_id"
-	DefaultLogKeyComponent     DefaultLogKey = "component"
-	DefaultLogKeyOperation     DefaultLogKey = "operation"
-	DefaultLogKeyStatus        DefaultLogKey = "status"
-	DefaultLogKeyLatency       DefaultLogKey = "latency"
-	DefaultLogKeyRequestID     DefaultLogKey = "request_id"
-	DefaultLogKeyResponseTime  DefaultLogKey = "response_time"
-	DefaultLogKeyClientIP      DefaultLogKey = "client_ip"
-	DefaultLogKeyServerIP      DefaultLogKey = "server_ip"
-	DefaultLogKeyProtocol      DefaultLogKey = "protocol"
-	DefaultLogKeyMethod        DefaultLogKey = "method"
-	DefaultLogKeyURL           DefaultLogKey = "url"
-	DefaultLogKeyStatusCode    DefaultLogKey = "status_code"
-	DefaultLogKeyContentType   DefaultLogKey = "content_type"
+	// DefaultLogKeyComponent is the key for the logical component or module name field.
+	DefaultLogKeyComponent DefaultLogKey = "component"
+	// DefaultLogKeyOperation is the key for the operation or action name field.
+	DefaultLogKeyOperation DefaultLogKey = "operation"
+	// DefaultLogKeyStatus is the key for an operation status descriptor field.
+	DefaultLogKeyStatus DefaultLogKey = "status"
+	// DefaultLogKeyLatency is the key for the request latency measurement field.
+	DefaultLogKeyLatency DefaultLogKey = "latency"
+	// DefaultLogKeyRequestID is the key for a unique request identifier field.
+	DefaultLogKeyRequestID DefaultLogKey = "request_id"
+	// DefaultLogKeyResponseTime is the key for the total response time field.
+	DefaultLogKeyResponseTime DefaultLogKey = "response_time"
+	// DefaultLogKeyClientIP is the key for the client IP address field.
+	DefaultLogKeyClientIP DefaultLogKey = "client_ip"
+	// DefaultLogKeyServerIP is the key for the server IP address field.
+	DefaultLogKeyServerIP DefaultLogKey = "server_ip"
+	// DefaultLogKeyProtocol is the key for the network protocol field (e.g. "HTTP/1.1").
+	DefaultLogKeyProtocol DefaultLogKey = "protocol"
+	// DefaultLogKeyMethod is the key for the HTTP (or RPC) method field.
+	DefaultLogKeyMethod DefaultLogKey = "method"
+	// DefaultLogKeyURL is the key for the request URL field.
+	DefaultLogKeyURL DefaultLogKey = "url"
+	// DefaultLogKeyStatusCode is the key for the HTTP response status code field.
+	DefaultLogKeyStatusCode DefaultLogKey = "status_code"
+	// DefaultLogKeyContentType is the key for the Content-Type header field.
+	DefaultLogKeyContentType DefaultLogKey = "content_type"
+	// DefaultLogKeyContentLength is the key for the Content-Length header field.
 	DefaultLogKeyContentLength DefaultLogKey = "content_length"
-	DefaultLogKeyResponseSize  DefaultLogKey = "response_size"
-	DefaultLogKeyRequestSize   DefaultLogKey = "request_size"
-	DefaultLogKeyUserAgent     DefaultLogKey = "user_agent"
-	DefaultLogKeyReferer       DefaultLogKey = "referer"
-	DefaultLogKeyForwardedFor  DefaultLogKey = "forwarded_for"
-	DefaultLogKeyCustom        DefaultLogKey = "custom"
+	// DefaultLogKeyResponseSize is the key for the response body size in bytes field.
+	DefaultLogKeyResponseSize DefaultLogKey = "response_size"
+	// DefaultLogKeyRequestSize is the key for the request body size in bytes field.
+	DefaultLogKeyRequestSize DefaultLogKey = "request_size"
+	// DefaultLogKeyUserAgent is the key for the User-Agent header field.
+	DefaultLogKeyUserAgent DefaultLogKey = "user_agent"
+	// DefaultLogKeyReferer is the key for the Referer header field.
+	DefaultLogKeyReferer DefaultLogKey = "referer"
+	// DefaultLogKeyForwardedFor is the key for the X-Forwarded-For header field.
+	DefaultLogKeyForwardedFor DefaultLogKey = "forwarded_for"
+	// DefaultLogKeyCustom is the key for user-defined custom metadata fields.
+	DefaultLogKeyCustom DefaultLogKey = "custom"
 )

--- a/enum/level.go
+++ b/enum/level.go
@@ -4,14 +4,23 @@ import (
 	"fmt"
 )
 
+// LogLevel is a numeric severity level used to filter and label log entries.
+// Higher values are more severe. Use the named constants (LevelDebug through
+// LevelFatal) rather than raw integers.
 type LogLevel int
 
 const (
+	// LevelUnSet is the zero-config catch-all level that matches every log event.
 	LevelUnSet LogLevel = 1 << iota
+	// LevelDebug is the lowest named severity, intended for verbose diagnostic output.
 	LevelDebug LogLevel = 1 << iota
-	LevelInfo  LogLevel = 1 << iota
-	LevelWarn  LogLevel = 1 << iota
+	// LevelInfo is the standard informational severity for routine operational messages.
+	LevelInfo LogLevel = 1 << iota
+	// LevelWarn indicates a recoverable condition that may warrant attention.
+	LevelWarn LogLevel = 1 << iota
+	// LevelError indicates a failure that has been handled but should be investigated.
 	LevelError LogLevel = 1 << iota
+	// LevelFatal is the highest named severity; callers typically exit after logging at this level.
 	LevelFatal LogLevel = 1 << iota
 )
 

--- a/enum/log_encode_type.go
+++ b/enum/log_encode_type.go
@@ -1,8 +1,12 @@
 package enum
 
+// LogEncodeType identifies the wire format used to serialise log entries.
+// Pass it to config.SetEncoderType to switch the active encoder.
 type LogEncodeType string
 
 const (
+	// EncoderJSON serialises log entries as single-line JSON objects.
 	EncoderJSON LogEncodeType = "json"
+	// EncoderText serialises log entries as plain text lines without JSON framing.
 	EncoderText LogEncodeType = "text"
 )


### PR DESCRIPTION
## Summary

Epic OS — Open Source Readiness. All 5 stories implemented:

| Story | PR | What it adds |
|-------|----|-------------|
| OS1 — CONTRIBUTING + CoC + templates | #103 | CONTRIBUTING.md, CODE_OF_CONDUCT.md, PR template, bug/feature issue templates |
| OS2 — SECURITY.md update | #100 | v1.x/v2.x supported versions, remove MAINTAINERS.md ref |
| OS3 — golangci-lint + CI on develop | #101 | .golangci.yml, lint workflow, test CI extended to develop branch |
| OS4 — godoc audit | #104 | Missing doc comments on all exported types/funcs/consts in enum, config packages |
| OS5 — CHANGELOG + API stability | #102 | CHANGELOG.md (Keep a Changelog format), semver contract section in README |

## Test plan

- [x] `go build ./...` clean
- [x] All files created and committed in isolated worktrees
- [x] STATUS.md updated — Epic OS ✅ DONE
- [x] All OS1–OS5 issues referenced

Fixes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)