### PR TITLE
fix: lint issues + coverage ≥ 85% per package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -155,7 +155,7 @@ func GetHotSnapshot() HotSnapshot {
 	snap := HotSnapshot{
 		AddSource:        defaultConfig.addSource,
 		TimeFormat:       defaultConfig.timeFormat,
-		DefaultFields:    defaultConfig.defaultFields,    // DO NOT MUTATE — shared reference
+		DefaultFields:    defaultConfig.defaultFields,         // DO NOT MUTATE — shared reference
 		Rendered:         defaultConfig.defaultFieldsRendered, // DO NOT MUTATE — shared reference
 		StaticFields:     defaultConfig.parsedStaticFields,
 		ContextParser:    defaultConfig.contextParser,
@@ -198,19 +198,19 @@ func init() {
 // configMu; use the exported Set* mutators and Get* accessors rather than
 // reading or writing fields directly.
 type Config struct {
-	minLevel              enum.LogLevel                      // Minimum log level to log
-	encoderType           enum.LogEncodeType                 // Encoder type to use for logging
-	encoderObj            encoder.Encoder                    // encoder for the data
-	addSource             bool                               // Whether to add source information to logs
-	output                io.Writer                          // Output writer for logs
-	logBufferMaxSize      int                                // max Buffer size for logs
-	rate                  time.Duration                      // Rate to push logs to output
-	parsedStaticFields    string                             // this is the satic fields
-	contextParser         ContextFieldsParser                // Function to extract context fields
-	contextAppender       ContextFieldsAppender              // High-performance context-field writer (P3)
-	defaultFields         map[enum.DefaultLogKey]string      // Default fields to log with every entry
-	defaultFieldsRendered map[enum.DefaultLogKey][]byte      // pre-rendered `"key":` prefix bytes; populated by buildRenderedFields
-	timeFormat            string                             // Time format for log entries
+	minLevel              enum.LogLevel                 // Minimum log level to log
+	encoderType           enum.LogEncodeType            // Encoder type to use for logging
+	encoderObj            encoder.Encoder               // encoder for the data
+	addSource             bool                          // Whether to add source information to logs
+	output                io.Writer                     // Output writer for logs
+	logBufferMaxSize      int                           // max Buffer size for logs
+	rate                  time.Duration                 // Rate to push logs to output
+	parsedStaticFields    string                        // this is the satic fields
+	contextParser         ContextFieldsParser           // Function to extract context fields
+	contextAppender       ContextFieldsAppender         // High-performance context-field writer (P3)
+	defaultFields         map[enum.DefaultLogKey]string // Default fields to log with every entry
+	defaultFieldsRendered map[enum.DefaultLogKey][]byte // pre-rendered `"key":` prefix bytes; populated by buildRenderedFields
+	timeFormat            string                        // Time format for log entries
 	hooks                 map[enum.LogLevel]map[string]PublishLogMessageHookContract
 }
 

--- a/config/coverage_gaps_test.go
+++ b/config/coverage_gaps_test.go
@@ -1,0 +1,140 @@
+//go:build testing
+
+package config_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/enum"
+	"github.com/architagr/lognugget/model"
+)
+
+// --- Config accessor coverage ---
+
+func Test_Config_StaticFields(t *testing.T) {
+	t.Cleanup(config.TestResetConfig)
+	config.SetStaticEnvFieldsParser(func() map[string]any { return map[string]any{"env": "test"} })
+	if got := config.GetConfig().StaticFields(); got == "" {
+		t.Error("StaticFields() should be non-empty after SetStaticEnvFieldsParser")
+	}
+}
+
+func Test_Config_ContextParser(t *testing.T) {
+	t.Cleanup(config.TestResetConfig)
+	if got := config.GetConfig().ContextParser(); got != nil {
+		t.Error("default ContextParser should be nil")
+	}
+}
+
+func Test_Config_TimeFormat(t *testing.T) {
+	t.Cleanup(config.TestResetConfig)
+	if got := config.GetConfig().TimeFormat(); got == "" {
+		t.Error("TimeFormat() should be non-empty by default")
+	}
+}
+
+func Test_Config_Encoder(t *testing.T) {
+	t.Cleanup(config.TestResetConfig)
+	if got := config.GetConfig().Encoder(); got == nil {
+		t.Error("Encoder() should be non-nil by default")
+	}
+}
+
+// --- Setter missing-branch coverage ---
+
+func Test_SetOutput_NilFallsBackToDefault(t *testing.T) {
+	t.Cleanup(config.TestResetConfig)
+	config.SetOutput(nil)
+	if got := config.GetConfig().Output(); got == nil {
+		t.Error("SetOutput(nil) should fall back to DefaultOutput, not nil")
+	}
+}
+
+func Test_SetRate_ZeroFallsBackToDefault(t *testing.T) {
+	t.Cleanup(config.TestResetConfig)
+	config.SetRate(0)
+	if got := config.GetConfig().Rate(); got != time.Second {
+		t.Errorf("SetRate(0) = %v; want 1s", got)
+	}
+}
+
+func Test_SetEncoderType_UnknownFallsBackToJSON(t *testing.T) {
+	t.Cleanup(config.TestResetConfig)
+	config.SetEncoderType(enum.LogEncodeType("bogus"))
+	if got := config.GetConfig().Encoder(); got == nil {
+		t.Error("SetEncoderType(unknown) should fall back to JSON encoder")
+	}
+}
+
+// --- AppendAttr KindAny uncovered type paths ---
+
+func Test_AppendAttr_KindAny_IntVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		attr model.LogAttr
+		want string
+	}{
+		{"int8", model.LogAttr{Key: "k", Value: int8(1)}, `"k":1`},
+		{"int16", model.LogAttr{Key: "k", Value: int16(2)}, `"k":2`},
+		{"int32", model.LogAttr{Key: "k", Value: int32(3)}, `"k":3`},
+		{"uint", model.LogAttr{Key: "k", Value: uint(4)}, `"k":4`},
+		{"uint8", model.LogAttr{Key: "k", Value: uint8(5)}, `"k":5`},
+		{"uint16", model.LogAttr{Key: "k", Value: uint16(6)}, `"k":6`},
+		{"uint32", model.LogAttr{Key: "k", Value: uint32(7)}, `"k":7`},
+		{"uint64", model.LogAttr{Key: "k", Value: uint64(8)}, `"k":8`},
+		{"bool", model.LogAttr{Key: "k", Value: true}, `"k":true`},
+	}
+	for _, tc := range cases {
+		got := string(config.AppendAttr(nil, "k", tc.attr))
+		if got != tc.want {
+			t.Errorf("%s: got %q want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func Test_AppendAttr_KindAny_Float32(t *testing.T) {
+	got := string(config.AppendAttr(nil, "k", model.LogAttr{Key: "k", Value: float32(1.5)}))
+	if got != `"k":1.5` {
+		t.Errorf("got %q want %q", got, `"k":1.5`)
+	}
+}
+
+func Test_AppendAttr_KindAny_Float32_NaN(t *testing.T) {
+	got := string(config.AppendAttr(nil, "k", model.LogAttr{Key: "k", Value: float32(float64(^uint32(0)>>1+1))}))
+	// any non-panic result is acceptable; just verify it doesn't crash
+	_ = got
+}
+
+// --- appendJSONString invalid UTF-8 path (via AppendAttr KindStr) ---
+
+func Test_AppendAttr_Str_InvalidUTF8(t *testing.T) {
+	// A lone 0xFF byte is invalid UTF-8; AppendAttr must not panic.
+	got := config.AppendAttr(nil, "k", model.Str("k", "\xff"))
+	if len(got) == 0 {
+		t.Error("expected non-empty output for invalid UTF-8 input")
+	}
+}
+
+func Test_AppendAttr_Str_MultibyteUTF8(t *testing.T) {
+	got := string(config.AppendAttr(nil, "k", model.Str("k", "日本語")))
+	if got != `"k":"日本語"` {
+		t.Errorf("got %q want %q", got, `"k":"日本語"`)
+	}
+}
+
+// --- SetDefaultFields missing branch ---
+
+func Test_SetDefaultFields_WithOutput(t *testing.T) {
+	t.Cleanup(config.TestResetConfig)
+	var buf bytes.Buffer
+	config.SetOutput(&buf)
+	config.SetDefaultFields(map[enum.DefaultLogKey]string{
+		enum.DefaultLogKeyLevel: "severity",
+	})
+	if got := config.GetConfig().DefaultFields(); got[enum.DefaultLogKeyLevel] != "severity" {
+		t.Errorf("DefaultFields level key = %q; want %q", got[enum.DefaultLogKeyLevel], "severity")
+	}
+}

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -55,7 +55,7 @@ var noopCloseBytesNewline = []byte{'\n'}
 // CloseBytes returns "\n" (universal newline terminator, ARCH-14).
 type NoopFramer struct{}
 
-func (NoopFramer) OpenBytes() []byte { return nil }
+func (NoopFramer) OpenBytes() []byte  { return nil }
 func (NoopFramer) CloseBytes() []byte { return noopCloseBytesNewline }
 
 // DefaultEncoderFactory returns the Encoder for the given LogEncodeType.

--- a/encoder/json_encoder.go
+++ b/encoder/json_encoder.go
@@ -1,7 +1,5 @@
 package encoder
 
-import "unicode/utf8"
-
 // compile-time proof that JSONEncoder satisfies the Encoder interface.
 var _ Encoder = (*JSONEncoder)(nil)
 
@@ -20,8 +18,6 @@ const (
 	escT    uint8 = 8 // \t
 )
 
-var hexDigits = "0123456789abcdef"
-
 func init() {
 	for i := 0; i <= 0x1f; i++ {
 		jsonEscapeTable[i] = escHex
@@ -33,48 +29,6 @@ func init() {
 	jsonEscapeTable['\n'] = escN
 	jsonEscapeTable['\r'] = escR
 	jsonEscapeTable['\t'] = escT
-}
-
-// escapeJSON appends src to dst with RFC 8259 string escaping applied.
-// Invalid UTF-8 bytes are replaced with the Unicode replacement character (U+FFFD).
-// dst may be nil; a new slice is allocated as needed.
-func escapeJSON(dst, src []byte) []byte {
-	for i := 0; i < len(src); {
-		b := src[i]
-		if b >= utf8.RuneSelf {
-			r, size := utf8.DecodeRune(src[i:])
-			if r == utf8.RuneError && size == 1 {
-				dst = append(dst, '\xef', '\xbf', '\xbd') // U+FFFD replacement char
-				i++
-				continue
-			}
-			dst = append(dst, src[i:i+size]...)
-			i += size
-			continue
-		}
-		switch jsonEscapeTable[b] {
-		case 0:
-			dst = append(dst, b)
-		case escHex:
-			dst = append(dst, '\\', 'u', '0', '0', hexDigits[b>>4], hexDigits[b&0xf])
-		case escQuot:
-			dst = append(dst, '\\', '"')
-		case escBksl:
-			dst = append(dst, '\\', '\\')
-		case escB:
-			dst = append(dst, '\\', 'b')
-		case escF:
-			dst = append(dst, '\\', 'f')
-		case escN:
-			dst = append(dst, '\\', 'n')
-		case escR:
-			dst = append(dst, '\\', 'r')
-		case escT:
-			dst = append(dst, '\\', 't')
-		}
-		i++
-	}
-	return dst
 }
 
 // JSONEncoder wraps a pre-rendered log body in JSON object braces and appends

--- a/encoder/json_encoder_test.go
+++ b/encoder/json_encoder_test.go
@@ -1,8 +1,6 @@
 package encoder
 
 import (
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -30,73 +28,17 @@ func Test_JSONEncoder_Append_WrapsInBraces(t *testing.T) {
 	}
 }
 
-// Test_JSONEncoder_Escape covers TS-16: escape table handles every RFC 8259 case.
-func Test_JSONEncoder_Escape(t *testing.T) {
+// Test_JSONEncoder_Append_EscapedBody verifies Append passes body bytes through
+// verbatim — escaping is the caller's responsibility (done by config.AppendQuotedString).
+func Test_JSONEncoder_Append_EscapedBody(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name string
-		in   []byte
-		want string
-	}{
-		{"double quote", []byte(`"`), `\"`},
-		{"backslash", []byte(`\`), `\\`},
-		{"backspace", []byte{'\b'}, `\b`},
-		{"formfeed", []byte{'\f'}, `\f`},
-		{"newline", []byte{'\n'}, `\n`},
-		{"carriage return", []byte{'\r'}, `\r`},
-		{"tab", []byte{'\t'}, `\t`},
-		{"null byte U+0000", []byte{0x00}, "\\u0000"},
-		{"control U+0001", []byte{0x01}, "\\u0001"},
-		{"control U+001F", []byte{0x1f}, "\\u001f"},
-		{"ascii printable", []byte("hello"), "hello"},
-		{"valid multibyte UTF-8", []byte("\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e"), "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e"},
-		{"invalid UTF-8 single byte", []byte{0xff}, "\xef\xbf\xbd"},
-		{"mixed", []byte("say \"hi\"\n"), "say \\\"hi\\\"\\n"},
-	}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			got := escapeJSON(nil, tc.in)
-			if string(got) != tc.want {
-				t.Fatalf("escapeJSON(%q) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
-	}
-}
-
-// Test_JSONEncoder_Numerics_Unquoted verifies digit bytes pass through unchanged.
-func Test_JSONEncoder_Numerics_Unquoted(t *testing.T) {
-	t.Parallel()
-
-	cases := []string{"42", "3.14", "-1", "1e10", "0"}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc, func(t *testing.T) {
-			t.Parallel()
-			got := escapeJSON(nil, []byte(tc))
-			if string(got) != tc {
-				t.Fatalf("escapeJSON(%q) = %q; numerics must pass through unchanged", tc, got)
-			}
-		})
-	}
-}
-
-// Test_JSONEncoder_UnicodeGolden compares escapeJSON output against the golden file.
-func Test_JSONEncoder_UnicodeGolden(t *testing.T) {
-	t.Parallel()
-
-	// Explicit byte slice avoids NUL in source literal.
-	input := []byte{'"', 'h', 'e', 'l', 'l', 'o', '"', '\\', '\n', '\t', '\b', '\f', '\r', 0x00, 0x1f}
-	got := escapeJSON(nil, input)
-
-	golden := filepath.Join("..", "testdata", "golden", "unicode_escape.json")
-	want, err := os.ReadFile(golden)
-	if err != nil {
-		t.Fatalf("read golden: %v", err)
-	}
-	if string(got) != string(want) {
-		t.Fatalf("mismatch\ngot:  %q\nwant: %q", got, want)
+	enc := NewJSONEncoder()
+	// Body already escaped by the caller; Append must not re-escape.
+	body := []byte(`"key":"say \"hi\"\n"`)
+	got := enc.Append(nil, body)
+	want := "{" + string(body) + "}\n"
+	if string(got) != want {
+		t.Fatalf("got %q, want %q", got, want)
 	}
 }

--- a/enum/level_test.go
+++ b/enum/level_test.go
@@ -1,0 +1,24 @@
+//go:build testing
+
+package enum
+
+import "testing"
+
+func Test_LogLevel_String(t *testing.T) {
+	cases := []struct {
+		level LogLevel
+		want  string
+	}{
+		{LevelDebug, "DEBUG"},
+		{LevelInfo, "INFO"},
+		{LevelWarn, "WARN"},
+		{LevelError, "ERROR"},
+		{LevelFatal, "FATAL"},
+		{LevelError + 1, "ERROR+1"}, // default branch
+	}
+	for _, tc := range cases {
+		if got := tc.level.String(); got != tc.want {
+			t.Errorf("LogLevel(%d).String() = %q; want %q", tc.level, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Remove dead `escapeJSON`/`hexDigits` from `encoder/json_encoder.go` (unused in production, flagged by golangci-lint `unused`)
- Fix gofmt in `encoder/encoder.go` and `config/config.go`
- Add `enum/level_test.go` — `LogLevel.String()` coverage (0% → 90.9%)
- Add `config/coverage_gaps_test.go` — Config accessors, setter edge cases, `AppendAttr` KindAny paths (83.4% → 95.3%)
- Update `encoder/json_encoder_test.go` — remove internal `escapeJSON` calls, test via `Append` (100%)

## Test plan
- [x] `golangci-lint run` — clean
- [x] `go test ./... -tags testing -race` — all pass
- [x] All packages ≥ 85% coverage