### PR TITLE
release: v2.0.2 — fix golangci-lint config schema

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,3 @@
-version: "2"
 linters:
   enable:
     - gofmt


### PR DESCRIPTION
Remove `version: "2"` from .golangci.yml — field is invalid in golangci-lint v1.x schema.