### PR TITLE
release: v2.0.3 — fix gofmt formatting in 7 test files

### DIFF
--- a/config/collision_test.go
+++ b/config/collision_test.go
@@ -43,11 +43,11 @@ func Test_ValidateAndParse_PrefixesCollidingKey(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		setup       func() // optional config mutation before assertion
-		teardown    func() // optional cleanup
-		inputKey    string
-		inputValue  any
+		name         string
+		setup        func() // optional config mutation before assertion
+		teardown     func() // optional cleanup
+		inputKey     string
+		inputValue   any
 		wantPrefixed bool // true → output should contain "custom.<key>"
 	}{
 		// --- Built-in defaults (no SetDefaultFields call needed) ---

--- a/config/config_race_test.go
+++ b/config/config_race_test.go
@@ -25,9 +25,9 @@ import (
 // test is the canonical proof that issue #54 is resolved.
 func Test_Race_ResetConfig_UnderConcurrentSet(t *testing.T) {
 	const (
-		numWriters  = 10
+		numWriters   = 10
 		numResetters = 5
-		iterations  = 20
+		iterations   = 20
 	)
 
 	var wg sync.WaitGroup
@@ -128,9 +128,9 @@ func Test_Race_ProcessLogEvent_UnderConcurrentReset(t *testing.T) {
 // result is a data race on the pointer itself.
 func Test_Race_GetConfig_UnderConcurrentSet(t *testing.T) {
 	const (
-		numReaders  = 8
-		numWriters  = 8
-		iterations  = 25
+		numReaders = 8
+		numWriters = 8
+		iterations = 25
 	)
 
 	var wg sync.WaitGroup

--- a/config/coverage_gaps_test.go
+++ b/config/coverage_gaps_test.go
@@ -103,7 +103,7 @@ func Test_AppendAttr_KindAny_Float32(t *testing.T) {
 }
 
 func Test_AppendAttr_KindAny_Float32_NaN(t *testing.T) {
-	got := string(config.AppendAttr(nil, "k", model.LogAttr{Key: "k", Value: float32(float64(^uint32(0)>>1+1))}))
+	got := string(config.AppendAttr(nil, "k", model.LogAttr{Key: "k", Value: float32(float64(^uint32(0)>>1 + 1))}))
 	// any non-panic result is acceptable; just verify it doesn't crash
 	_ = got
 }

--- a/config/publish_test.go
+++ b/config/publish_test.go
@@ -197,7 +197,7 @@ func Test_PublishLog(t *testing.T) {
 	t.Run("RaceConcurrent", func(t *testing.T) {
 		const (
 			numGoroutines = 100
-			numPublishes  = 1  // 1 per goroutine = 100 total; fits in channel buffer
+			numPublishes  = 1 // 1 per goroutine = 100 total; fits in channel buffer
 			wantTotal     = numGoroutines * numPublishes
 		)
 

--- a/entry/ctx_appender_bench_test.go
+++ b/entry/ctx_appender_bench_test.go
@@ -65,7 +65,7 @@ func BenchmarkLogEntry_CtxParser_10(b *testing.B) {
 		return map[string]any{
 			"req_id":  "req-abc",
 			"user_id": "bench-user",
-			"k1": "v1", "k2": "v2", "k3": "v3",
+			"k1":      "v1", "k2": "v2", "k3": "v3",
 			"k4": "v4", "k5": "v5", "k6": "v6",
 			"k7": "v7", "k8": "v8", "k9": "v9",
 		}

--- a/test/integration/collision_prefix_test.go
+++ b/test/integration/collision_prefix_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/architagr/lognugget/test/support"
 )
 
-
 // drainSpyIntegration polls spy.Records() until at least one record is
 // available, failing after a time-bounded number of iterations.
 //

--- a/test/integration/hook_fanout_test.go
+++ b/test/integration/hook_fanout_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	pipelineStage "github.com/architagr/lognugget/pipeline_stage"
 	"github.com/architagr/lognugget/config"
 	"github.com/architagr/lognugget/enum"
+	pipelineStage "github.com/architagr/lognugget/pipeline_stage"
 	"github.com/architagr/lognugget/test/support"
 )
 
@@ -101,7 +101,7 @@ func Test_Integration_HookFanout_BothHooksCoexist(t *testing.T) {
 	infoPayload := []byte(`{"level":"info","msg":"coexist"}`)
 	debugPayload := []byte(`{"level":"debug","msg":"coexist"}`)
 
-	config.PublishLog(enum.LevelInfo, infoPayload)  // → allHook + infoHook
+	config.PublishLog(enum.LevelInfo, infoPayload)   // → allHook + infoHook
 	config.PublishLog(enum.LevelDebug, debugPayload) // → allHook only
 
 	// allHook must receive 2 events (info + debug).


### PR DESCRIPTION
## Summary
- Fix gofmt tab-alignment issues in 7 test files flagged by CI `.ci.gofmt.sh`
- Affected: `config/collision_test.go`, `config/config_race_test.go`, `config/coverage_gaps_test.go`, `config/publish_test.go`, `entry/ctx_appender_bench_test.go`, `test/integration/collision_prefix_test.go`, `test/integration/hook_fanout_test.go`

## Test plan
- [x] CI Lint passes on develop (run 26274485868)
- [x] CI All builds passes on develop (run 26274485951)
- No logic changes; formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)