### PR TITLE
feat(config): V3-P1 atomic.Bool preprocessor gate

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,9 @@
 // acquire configMu (read). This satisfies the race-freedom requirement
 // tracked in issue #54 / story 039 without the allocation overhead of a
 // copy-on-write atomic.Pointer approach (see bench-baseline.txt for
-// the < 1 µs budget).
+// the < 1 µs budget). Hot-path booleans (HasEventPreProcessors) are
+// additionally mirrored into atomic.Bool fields so the most frequent
+// callers pay a single load instruction rather than a full RLock pair.
 package config
 
 import (
@@ -54,6 +56,18 @@ var (
 // on the filtered path removes ~200 ns of contention per filtered event,
 // keeping the overall call budget inside the < 1 µs SLO (Epic V2 / LLD §2.1).
 var atomicMinLevel atomic.Int64
+
+// hasPreProcessorsAtomic mirrors len(EventPreProcessors) > 0 as an atomic.Bool
+// so that HasEventPreProcessors can short-circuit without acquiring configMu.
+// It is stored inside configMu.Lock in every mutator (InitPreProcessors,
+// AddPreProcessors, RemovePreProcessor, resetConfig) to stay consistent with
+// the guarded map.
+//
+// why: the former RLock+RUnlock pair in HasEventPreProcessors cost ~80 ns on the
+// hot log path (V3-P1 / LLD §3.1). atomic.Bool.Load is a single memory barrier
+// with no scheduler interaction, bringing the check to < 1 ns/op (see
+// BenchmarkHasEventPreProcessors in preprocessor_gate_bench_test.go).
+var hasPreProcessorsAtomic atomic.Bool
 
 // Compile-time width guard: enum.LogLevel must fit in int64 so the atomic
 // store is lossless. If LogLevel ever widens beyond int64 this line will
@@ -254,6 +268,9 @@ func InitPreProcessors(observers ...preProcessingObserverContract) {
 	for _, observer := range observers {
 		EventPreProcessors[observer.Name()] = observer
 	}
+	// why: store inside the lock so HasEventPreProcessors sees a consistent value
+	// with respect to every other configMu writer (V3-P1 / LLD §3.1).
+	hasPreProcessorsAtomic.Store(len(EventPreProcessors) > 0)
 }
 
 // AddPreProcessors registers one or more pre-processors into the global
@@ -264,17 +281,22 @@ func AddPreProcessors(observers ...preProcessingObserverContract) {
 	for _, observer := range observers {
 		EventPreProcessors[observer.Name()] = observer
 	}
+	// why: store inside the lock so HasEventPreProcessors sees a consistent value
+	// with respect to every other configMu writer (V3-P1 / LLD §3.1).
+	hasPreProcessorsAtomic.Store(len(EventPreProcessors) > 0)
 }
 
 // HasEventPreProcessors reports whether at least one pre-processor is
-// registered. It acquires configMu.RLock so it is safe for concurrent use and
-// produces no data races. The hot path in logWithSkip calls this instead of
-// reading EventPreProcessors directly (which is an unsynchronised map access).
+// registered. It reads hasPreProcessorsAtomic with a single atomic load —
+// no lock is acquired — making it safe for concurrent use with zero contention
+// on the hot log path (V3-P1 / LLD §3.1).
+//
+// why: the former RLock+RUnlock pair cost ~80 ns per call; an atomic.Bool.Load
+// costs < 1 ns. The value is kept consistent by all mutators (InitPreProcessors,
+// AddPreProcessors, RemovePreProcessor, resetConfig) which store to
+// hasPreProcessorsAtomic inside their configMu.Lock sections.
 func HasEventPreProcessors() bool {
-	configMu.RLock()
-	n := len(EventPreProcessors)
-	configMu.RUnlock()
-	return n > 0
+	return hasPreProcessorsAtomic.Load()
 }
 
 // RemovePreProcessor deletes the named pre-processor from the global map.
@@ -283,6 +305,9 @@ func RemovePreProcessor(name string) {
 	configMu.Lock()
 	defer configMu.Unlock()
 	delete(EventPreProcessors, name)
+	// why: store inside the lock so HasEventPreProcessors sees a consistent value
+	// with respect to every other configMu writer (V3-P1 / LLD §3.1).
+	hasPreProcessorsAtomic.Store(len(EventPreProcessors) > 0)
 }
 
 // SetMinLevel sets the minimum log level for the logger. It stores the level
@@ -715,6 +740,11 @@ func resetConfig() {
 	ch = newCh
 	defaultConfig = newCfg
 	EventPreProcessors = make(map[string]preProcessingObserverContract)
+	// why: mirror the reset into the atomic so HasEventPreProcessors immediately
+	// observes false after TestResetConfig is called in tests (and at init).
+	// Without this store, the atomic would retain a stale true from a previous
+	// InitPreProcessors call across test resets (V3-P1 / LLD §3.1).
+	hasPreProcessorsAtomic.Store(false)
 	// why: restrictedFieldsSet must be rebuilt here so that
 	// ValidateandParseLogField works correctly from the very first call —
 	// even before any SetDefaultFields call is made. This is the fix for D-8:

--- a/config/preprocessor_gate_bench_test.go
+++ b/config/preprocessor_gate_bench_test.go
@@ -1,0 +1,26 @@
+//go:build testing
+
+// Package config_test provides benchmarks for the atomic preprocessor gate (V3-P1).
+package config_test
+
+import (
+	"testing"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/test/support"
+)
+
+// BenchmarkHasEventPreProcessors measures the hot-path cost of HasEventPreProcessors
+// after the V3-P1 atomic.Bool optimisation. Input: one registered processor (the
+// realistic steady state). p99 must stay <= 5 ns/op with 0 allocs/op;
+// the sub-1 µs budget from CLAUDE.md gives us ample headroom.
+func BenchmarkHasEventPreProcessors(b *testing.B) {
+	config.TestResetConfig()
+	fp := support.NewFakePreProc("p1")
+	config.InitPreProcessors(fp)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = config.HasEventPreProcessors()
+	}
+}

--- a/config/preprocessor_gate_test.go
+++ b/config/preprocessor_gate_test.go
@@ -1,0 +1,107 @@
+//go:build testing
+
+// Package config_test verifies the atomic preprocessor gate introduced in V3-P1.
+// These tests exercise HasEventPreProcessors, InitPreProcessors, AddPreProcessors,
+// and RemovePreProcessor to verify the atomic.Bool mirrors map state correctly
+// under concurrent access.
+package config_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/test/support"
+)
+
+// Test_HasPreProcessors_FalseOnEmpty asserts that HasEventPreProcessors returns
+// false when InitPreProcessors is called with no arguments.
+func Test_HasPreProcessors_FalseOnEmpty(t *testing.T) {
+	t.Cleanup(func() { config.TestResetConfig() })
+	config.TestResetConfig()
+	config.InitPreProcessors()
+	if config.HasEventPreProcessors() {
+		t.Fatal("expected false for empty processor set")
+	}
+}
+
+// Test_HasPreProcessors_TrueAfterInit asserts that HasEventPreProcessors returns
+// true after InitPreProcessors is called with at least one processor.
+func Test_HasPreProcessors_TrueAfterInit(t *testing.T) {
+	t.Cleanup(func() { config.TestResetConfig() })
+	config.TestResetConfig()
+	fp := support.NewFakePreProc("p1")
+	config.InitPreProcessors(fp)
+	if !config.HasEventPreProcessors() {
+		t.Fatal("expected true after InitPreProcessors with one processor")
+	}
+}
+
+// Test_HasPreProcessors_FalseAfterRemove asserts that HasEventPreProcessors returns
+// false after the last processor is removed via RemovePreProcessor.
+func Test_HasPreProcessors_FalseAfterRemove(t *testing.T) {
+	t.Cleanup(func() { config.TestResetConfig() })
+	config.TestResetConfig()
+	fp := support.NewFakePreProc("p1")
+	config.InitPreProcessors(fp)
+	config.RemovePreProcessor(fp.Name())
+	if config.HasEventPreProcessors() {
+		t.Fatal("expected false after removing last processor")
+	}
+}
+
+// Test_HasPreProcessors_TrueAfterAdd asserts that HasEventPreProcessors returns
+// true after a processor is registered via AddPreProcessors.
+func Test_HasPreProcessors_TrueAfterAdd(t *testing.T) {
+	t.Cleanup(func() { config.TestResetConfig() })
+	config.TestResetConfig()
+	fp := support.NewFakePreProc("p1")
+	config.AddPreProcessors(fp)
+	if !config.HasEventPreProcessors() {
+		t.Fatal("expected true after AddPreProcessors")
+	}
+}
+
+// Test_HasPreProcessors_FalseAfterReset asserts that HasEventPreProcessors returns
+// false immediately after TestResetConfig clears all state.
+func Test_HasPreProcessors_FalseAfterReset(t *testing.T) {
+	t.Cleanup(func() { config.TestResetConfig() })
+	config.TestResetConfig()
+	fp := support.NewFakePreProc("p1")
+	config.InitPreProcessors(fp)
+	config.TestResetConfig()
+	if config.HasEventPreProcessors() {
+		t.Fatal("expected false after TestResetConfig")
+	}
+}
+
+// Test_HasPreProcessors_Race verifies that concurrent adds, removes, and reads
+// of HasEventPreProcessors produce no data races under -race. Four goroutines
+// repeatedly add and remove a processor while four readers poll HasEventPreProcessors.
+func Test_HasPreProcessors_Race(t *testing.T) {
+	t.Cleanup(func() { config.TestResetConfig() })
+	config.TestResetConfig()
+	fp := support.NewFakePreProc("p1")
+	config.InitPreProcessors(fp)
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				config.AddPreProcessors(support.NewFakePreProc("tmp"))
+				config.RemovePreProcessor("tmp")
+			}
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				_ = config.HasEventPreProcessors()
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

- Replace `HasEventPreProcessors()` `configMu.RLock/RUnlock` pair with a single `atomic.Bool` load (V3-P1 / LLD §3.1)
- ~80 ns → ~0.55 ns/op on the hot log path; 0 allocs/op (verified by `BenchmarkHasEventPreProcessors`)
- `hasPreProcessorsAtomic` is stored inside `configMu.Lock` in all four mutators (`InitPreProcessors`, `AddPreProcessors`, `RemovePreProcessor`, `resetConfig`) to remain consistent with the guarded `EventPreProcessors` map

refs #112

## Test plan

- [x] `go test -tags testing -run Test_HasPreProcessors ./config/...` — all 6 cases green
- [x] `go test -tags testing -race -run Test_HasPreProcessors ./config/...` — no races
- [x] `go test -tags testing -bench=BenchmarkHasEventPreProcessors -benchmem -count=5 -run='^$' ./config/...` — ~0.55 ns/op, 0 allocs/op
- [x] `golangci-lint run ./...` — clean
- [ ] `./scripts/bench-check.sh` — blocked on pre-existing `Benchmark_Log_AddSourceTrue` failure (see note below)

## Pre-existing bench-check failure

`Benchmark_Log_AddSourceTrue` in `entry` package consistently exceeds 1000 ns/op (~1100-1180 ns/op) due to `runtime.Callers` overhead. This failure exists on `feat/111-v3-performance` **before** this PR's changes. Not introduced by this story. Escalating to Project Lead per CLAUDE.md step 9.

## Pre-existing test flakiness

Three tests in `config` are intermittently flaky on the base branch:
- `Test_ValidateAndParse_ReservedKeysPopulatedAtInit` — parallel test races with `SetDefaultFields` teardown
- `Test_LogEntry_UsesPrerenderedPrefixInOutput` — timing-based spy timeout
- `Test_Parsers` — timing-based spy timeout

All three fail on `feat/111-v3-performance` without this PR's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)