### PR TITLE
feat(config,entry): V3-P6 pre-rendered level bytes in AppendQuotedLevel

### DIFF
--- a/config/level_bytes_bench_test.go
+++ b/config/level_bytes_bench_test.go
@@ -1,0 +1,20 @@
+//go:build testing
+
+package config
+
+import (
+	"testing"
+
+	"github.com/architagr/lognugget/enum"
+)
+
+// BenchmarkAppendQuotedLevel_Named measures the pre-rendered fast path (no
+// level.String() call, no allocation).
+func BenchmarkAppendQuotedLevel_Named(b *testing.B) {
+	dst := make([]byte, 0, 16)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dst = AppendQuotedLevel(dst[:0], enum.LevelInfo)
+	}
+}

--- a/config/level_bytes_test.go
+++ b/config/level_bytes_test.go
@@ -44,6 +44,18 @@ func Test_AppendQuotedLevel_NoAlloc(t *testing.T) {
 	}
 }
 
+// Test_AppendQuotedLevel_UnknownLevel verifies that a level value not in the
+// switch falls back to AppendQuotedString without panicking and produces a
+// valid quoted JSON string.
+func Test_AppendQuotedLevel_UnknownLevel(t *testing.T) {
+	unknown := enum.LogLevel(99)
+	got := string(AppendQuotedLevel(nil, unknown))
+	// Must be a quoted, non-empty string — exact value depends on LogLevel.String().
+	if len(got) < 2 || got[0] != '"' || got[len(got)-1] != '"' {
+		t.Errorf("unknown level fallback produced invalid JSON string: %s", got)
+	}
+}
+
 // Test_AppendQuotedLevel_AppendToExisting verifies AppendQuotedLevel correctly
 // appends to a non-nil dst rather than overwriting it.
 func Test_AppendQuotedLevel_AppendToExisting(t *testing.T) {

--- a/config/level_bytes_test.go
+++ b/config/level_bytes_test.go
@@ -1,0 +1,56 @@
+//go:build testing
+
+package config
+
+import (
+	"testing"
+
+	"github.com/architagr/lognugget/enum"
+)
+
+func Test_AppendQuotedLevel_NamedLevels(t *testing.T) {
+	cases := []struct {
+		level enum.LogLevel
+		want  string
+	}{
+		{enum.LevelDebug, `"DEBUG"`},
+		{enum.LevelInfo, `"INFO"`},
+		{enum.LevelWarn, `"WARN"`},
+		{enum.LevelError, `"ERROR"`},
+		{enum.LevelFatal, `"FATAL"`},
+	}
+	for _, c := range cases {
+		got := string(AppendQuotedLevel(nil, c.level))
+		if got != c.want {
+			t.Errorf("level %v: got %s, want %s", c.level, got, c.want)
+		}
+	}
+}
+
+// Test_AppendQuotedLevel_NoAlloc verifies named levels produce no heap allocations
+// (they append pre-quoted byte literals, bypassing level.String()).
+func Test_AppendQuotedLevel_NoAlloc(t *testing.T) {
+	named := []enum.LogLevel{
+		enum.LevelDebug, enum.LevelInfo, enum.LevelWarn, enum.LevelError, enum.LevelFatal,
+	}
+	dst := make([]byte, 0, 16)
+	for _, l := range named {
+		allocs := testing.AllocsPerRun(100, func() {
+			dst = AppendQuotedLevel(dst[:0], l)
+		})
+		if allocs != 0 {
+			t.Errorf("level %v: got %.0f allocs, want 0", l, allocs)
+		}
+	}
+}
+
+// Test_AppendQuotedLevel_AppendToExisting verifies AppendQuotedLevel correctly
+// appends to a non-nil dst rather than overwriting it.
+func Test_AppendQuotedLevel_AppendToExisting(t *testing.T) {
+	prefix := []byte(`"level":`)
+	got := string(AppendQuotedLevel(append([]byte(nil), prefix...), enum.LevelInfo))
+	want := `"level":"INFO"`
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}

--- a/entry/entry.go
+++ b/entry/entry.go
@@ -185,7 +185,7 @@ func (e *LogEntry) logWithSkip(level enum.LogLevel, ctx context.Context, message
 	e.buf = append(e.buf, '"')
 	e.buf = append(e.buf, ',')
 	e.buf = append(e.buf, snap.Rendered[enum.DefaultLogKeyLevel]...)
-	e.buf = config.AppendQuotedString(e.buf, level.String())
+	e.buf = config.AppendQuotedLevel(e.buf, level)
 	e.buf = append(e.buf, ',')
 	e.buf = append(e.buf, snap.Rendered[enum.DefaultLogKeyMessage]...)
 	e.buf = config.AppendQuotedString(e.buf, message)

--- a/entry/timestamp_bench_test.go
+++ b/entry/timestamp_bench_test.go
@@ -1,0 +1,48 @@
+// Package entry_test: V3-P4 timestamp benchmark.
+//
+// Measures the allocation count and latency of the timestamp path after the
+// direct AppendFormat change. The target is 0 allocs/op attributable to the
+// timestamp formatting step, and an overall p99 < 1 µs.
+package entry_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	pipelineStage "github.com/architagr/lognugget/pipeline_stage"
+)
+
+type timestampBenchWriter struct{}
+
+func (w *timestampBenchWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// BenchmarkTimestamp_Direct measures the hot path with the direct
+// now.AppendFormat(e.buf, snap.TimeFormat) timestamp encoding, replacing the
+// former customTime.Format + AppendQuotedString (2 allocs). The target is
+// 0 allocs attributable to timestamp formatting; overall p99 must remain < 1 µs.
+//
+// Input shape: single-goroutine, no context fields, JSON encoder, Debug level.
+// Budget defended: sub-1 µs p99 per the LogNugget SLO (CLAUDE.md §Performance Gate).
+func BenchmarkTimestamp_Direct(b *testing.B) {
+	b.StopTimer()
+	out := &timestampBenchWriter{}
+	config.SetMinLevel(enum.LevelDebug)
+	config.SetEncoderType(enum.EncoderJSON)
+	unset := pipelineStage.NewUnsetLogEventPostProcessor(2*time.Second, 1000, out)
+	pipelineStage.EventPreProcessorObj.RegisterHook(enum.LevelUnSet, unset)
+	config.InitPreProcessors(pipelineStage.EventPreProcessorObj)
+	entry.GenerateInitialPool(10_000)
+	b.Cleanup(unset.Stop)
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		entry.NewLogEntry().Debug(ctx, "bench timestamp")
+	}
+}

--- a/entry/timestamp_test.go
+++ b/entry/timestamp_test.go
@@ -1,0 +1,99 @@
+//go:build testing
+
+// Package entry_test: V3-P4 timestamp-format correctness tests.
+//
+// These tests verify that the direct AppendFormat path (replacing
+// customTime.Format + AppendQuotedString) produces RFC 3339–valid timestamps
+// under the default format and correctly renders custom layouts. They run under
+// the `testing` build tag because they import the test/support package.
+package entry_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	"github.com/architagr/lognugget/test/support"
+)
+
+// drainTimestampRec polls spy.Records() until at least one record arrives,
+// returning the first record's raw bytes. Fails after 500 goroutine-yield
+// iterations — matching the pattern used in levels_test.go.
+func drainTimestampRec(t *testing.T, spy *support.FakePreProc) []byte {
+	t.Helper()
+	for i := 0; i < 500; i++ {
+		recs := spy.Records()
+		if len(recs) > 0 {
+			return recs[0].Data
+		}
+		// Yield to the scheduler without importing time.
+		done := make(chan struct{})
+		go func() { close(done) }()
+		<-done
+	}
+	t.Fatal("timed out waiting for log record; spy was never invoked — check config.InitPreProcessors")
+	return nil
+}
+
+// Test_LogEntry_TimestampFormat_RFC3339 verifies that the default time format
+// (time.RFC3339) produces a valid RFC 3339 timestamp in the "time" JSON field.
+// This is a regression guard: the direct AppendFormat path must produce output
+// identical in meaning to the former customTime.Format + AppendQuotedString path.
+func Test_LogEntry_TimestampFormat_RFC3339(t *testing.T) {
+	support.NewConfigBuilder(t).
+		MinLevel(enum.LevelDebug).
+		Encoder(enum.EncoderJSON).
+		Build()
+	spy := support.NewFakePreProc("ts-rfc3339")
+	config.InitPreProcessors(spy)
+
+	entry.NewLogEntry().Info(context.Background(), "test")
+
+	raw := drainTimestampRec(t, spy)
+
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("invalid JSON: %v — output: %s", err, raw)
+	}
+	ts, ok := m["time"].(string)
+	if !ok {
+		t.Fatalf("no 'time' string field in output: %s", raw)
+	}
+	if _, err := time.Parse(time.RFC3339, ts); err != nil {
+		t.Fatalf("timestamp %q is not valid RFC3339: %v", ts, err)
+	}
+}
+
+// Test_LogEntry_TimestampFormat_Custom verifies that a custom time layout
+// (date-only "2006-01-02") is honoured and the resulting value parses correctly.
+// This guards against the direct AppendFormat path silently ignoring snap.TimeFormat.
+func Test_LogEntry_TimestampFormat_Custom(t *testing.T) {
+	const layout = "2006-01-02"
+	support.NewConfigBuilder(t).
+		MinLevel(enum.LevelDebug).
+		Encoder(enum.EncoderJSON).
+		TimeFormat(layout).
+		Build()
+	spy := support.NewFakePreProc("ts-custom")
+	config.InitPreProcessors(spy)
+
+	entry.NewLogEntry().Info(context.Background(), "test")
+
+	raw := drainTimestampRec(t, spy)
+
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("invalid JSON: %v — output: %s", err, raw)
+	}
+	ts, ok := m["time"].(string)
+	if !ok {
+		t.Fatalf("no 'time' string field in output: %s", raw)
+	}
+	if _, err := time.Parse(layout, ts); err != nil {
+		t.Fatalf("timestamp %q does not match layout %q: %v", ts, layout, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `AppendQuotedLevel` to `config/parse_field.go` — switches over 5 named `LogLevel` constants and appends pre-quoted byte literals (`"DEBUG"`, `"INFO"`, etc.), eliminating `level.String()` and its ~15 ns / ~1 alloc per event
- Update `entry/entry.go` `logWithSkip` to call `AppendQuotedLevel` instead of `AppendQuotedString(buf, level.String())`
- Unknown levels fall back to `AppendQuotedString(dst, l.String())` for forward compatibility

## Test plan

- [ ] `Test_AppendQuotedLevel_NamedLevels` — all 5 named levels produce correct quoted output
- [ ] `Test_AppendQuotedLevel_NoAlloc` — zero allocs via `testing.AllocsPerRun`
- [ ] `Test_AppendQuotedLevel_AppendToExisting` — appends correctly to non-nil dst
- [ ] `BenchmarkAppendQuotedLevel_Named` — fast path benchmark (no alloc)
- [ ] `go test -tags testing ./...` — full suite green

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)