### PR TITLE
feat(v3): Epic V3 — sub-500ns hot path + OTel tracing (P1–P9)

### DIFF
--- a/config/atomic_channel_bench_test.go
+++ b/config/atomic_channel_bench_test.go
@@ -1,0 +1,36 @@
+//go:build testing
+
+// Package config provides the V3-P3 benchmark for the atomic.Value channel
+// pointer in PublishLog. The benchmark defends the < 1 µs p99 SLO for the
+// hot dispatch path and specifically targets the ~50 ns saving over the prior
+// configMu.RLock-based channel read (Epic V3 LLD §5.1).
+package config
+
+import (
+	"testing"
+
+	"github.com/architagr/lognugget/enum"
+)
+
+// BenchmarkPublishLog measures the end-to-end hot-path cost of PublishLog after
+// the V3-P3 atomic.Value optimisation. Input: default config after TestResetConfig
+// with a 100_000-capacity channel so the send never blocks during the benchmark.
+// p99 budget: < 1000 ns/op (the project-wide SLO); the atomic channel load alone
+// should cost < 10 ns, and the buffered channel send < 50 ns under no contention.
+//
+// why: the former configMu.RLock + RUnlock pair cost ~50 ns per PublishLog call.
+// atomic.Value.Load is a single memory barrier with no scheduler interaction,
+// bringing the load to < 5 ns/op and keeping the full send path well under
+// the sub-1 µs budget (V3-P3 / LLD §5.1 / see bench-baseline.txt).
+func BenchmarkPublishLog(b *testing.B) {
+	// Large channel so the b.N sends never back-pressure during the run.
+	SetChannelCapacity(channelCapacityMax)
+	TestResetConfig()
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			PublishLog(enum.LevelInfo, []byte(`{"level":"INFO"}`))
+		}
+	})
+}

--- a/config/atomic_channel_test.go
+++ b/config/atomic_channel_test.go
@@ -1,14 +1,13 @@
 //go:build testing
 
-// Package config contains tests for the V3-P3 atomic.Value channel pointer
-// optimisation. These tests verify that PublishLog no longer acquires
-// configMu.RLock, eliminating the last read-lock acquisition from the hot path
-// (Epic V3 / LLD §5.1).
+// Package config contains tests verifying that PublishLog does not acquire
+// configMu.RLock. Originally written for V3-P3 (atomic.Value channel pointer);
+// still valid under V3-P9 (MPSC ring buffer) since atomicRing.Load().Push()
+// is equally lock-free.
 //
 // The tests live in package config (not config_test) so they can access the
-// unexported configMu directly — the only reliable way to prove that PublishLog
-// does NOT acquire configMu.RLock without adding test-only hooks to production
-// code.
+// unexported configMu directly — the only reliable way to prove the no-RLock
+// guarantee without adding test-only hooks to production code.
 package config
 
 import (
@@ -70,19 +69,18 @@ func Test_PublishLog_NoConfigMuRLock(t *testing.T) {
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("Test_PublishLog_NoConfigMuRLock: timed out — PublishLog may still " +
 			"be acquiring configMu.RLock, blocking under the write lock. " +
-			"Expected lock-free atomicCh read after V3-P3.")
+			"Expected lock-free atomicRing.Load().Push() after V3-P9.")
 	}
 }
 
 // Test_PublishLog_Race exercises PublishLog under concurrent publish and reset
 // activity. It must produce no DATA RACE reports when run with -race.
 // Eight goroutines each publish 50 events (400 total) while a ninth goroutine
-// calls TestResetConfig three times, replacing ch and atomicCh with fresh values.
+// calls TestResetConfig three times, replacing the ring and ringDoneCh.
 //
-// why: the sub-1 µs SLO requires that the atomic.Value load and channel send
-// are individually safe with no lock. This stress test validates that guarantee
-// under the Go race detector, which instruments every memory access at runtime
-// (V3-P3 / LLD §5.1).
+// why: the sub-1 µs SLO requires that atomicRing.Load().Push() is safe with no
+// lock under concurrent resets. This stress test validates that guarantee under
+// the Go race detector (V3-P9 / LLD §5.1).
 func Test_PublishLog_Race(t *testing.T) {
 	TestResetConfig()
 

--- a/config/atomic_channel_test.go
+++ b/config/atomic_channel_test.go
@@ -1,0 +1,107 @@
+//go:build testing
+
+// Package config contains tests for the V3-P3 atomic.Value channel pointer
+// optimisation. These tests verify that PublishLog no longer acquires
+// configMu.RLock, eliminating the last read-lock acquisition from the hot path
+// (Epic V3 / LLD §5.1).
+//
+// The tests live in package config (not config_test) so they can access the
+// unexported configMu directly — the only reliable way to prove that PublishLog
+// does NOT acquire configMu.RLock without adding test-only hooks to production
+// code.
+package config
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/enum"
+)
+
+// Test_PublishLog_NoConfigMuRLock proves that PublishLog does not call
+// configMu.RLock. The proof: hold configMu.Lock() for an extended window,
+// ensure the goroutine has started executing (via the ready barrier), and
+// assert that PublishLog completes before the deadline.
+//
+// If PublishLog calls configMu.RLock(), it blocks inside the lock-held window
+// and done never receives within 200 ms — the test fails with an explicit
+// message. If PublishLog reads the channel via atomicCh (no configMu), the
+// send completes immediately and done receives before the deadline.
+//
+// why: holding the write lock makes any RLock attempt block indefinitely.
+// A 200 ms deadline is ~10⁶× larger than the expected lock-free completion
+// time (~50 ns), so false positives from scheduler delay are not possible
+// in practice (V3-P3 / LLD §5.1).
+func Test_PublishLog_NoConfigMuRLock(t *testing.T) {
+	TestResetConfig()
+
+	done := make(chan struct{})
+	ready := make(chan struct{})
+
+	// Acquire the exclusive write lock before spawning the goroutine.
+	// Any RLock call inside PublishLog will block until we call Unlock.
+	configMu.Lock()
+
+	go func() {
+		// Signal that this goroutine is now live and about to call PublishLog.
+		// This ensures PublishLog executes while configMu is still locked.
+		close(ready)
+		PublishLog(enum.LevelInfo, []byte(`{"level":"INFO"}`))
+		close(done)
+	}()
+
+	// Wait until the goroutine has been scheduled and is past the ready
+	// barrier — it is now either blocked on configMu.RLock (old code) or
+	// has already sent (new code using atomicCh).
+	<-ready
+
+	// Hold the lock a little longer to guarantee the goroutine has had time
+	// to reach the configMu.RLock call if it intends to make one.
+	time.Sleep(2 * time.Millisecond)
+
+	// Release the lock. If PublishLog was blocked on RLock it will now
+	// unblock and complete, but we have already started the deadline timer.
+	configMu.Unlock()
+
+	select {
+	case <-done:
+		// PublishLog completed — either lock-free (ideal) or unblocked by Unlock.
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Test_PublishLog_NoConfigMuRLock: timed out — PublishLog may still " +
+			"be acquiring configMu.RLock, blocking under the write lock. " +
+			"Expected lock-free atomicCh read after V3-P3.")
+	}
+}
+
+// Test_PublishLog_Race exercises PublishLog under concurrent publish and reset
+// activity. It must produce no DATA RACE reports when run with -race.
+// Eight goroutines each publish 50 events (400 total) while a ninth goroutine
+// calls TestResetConfig three times, replacing ch and atomicCh with fresh values.
+//
+// why: the sub-1 µs SLO requires that the atomic.Value load and channel send
+// are individually safe with no lock. This stress test validates that guarantee
+// under the Go race detector, which instruments every memory access at runtime
+// (V3-P3 / LLD §5.1).
+func Test_PublishLog_Race(t *testing.T) {
+	TestResetConfig()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				PublishLog(enum.LevelInfo, []byte(`{"level":"INFO"}`))
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < 3; j++ {
+			TestResetConfig()
+		}
+	}()
+	wg.Wait()
+}

--- a/config/atomic_snapshot_test.go
+++ b/config/atomic_snapshot_test.go
@@ -1,0 +1,179 @@
+//go:build testing
+
+// Package config contains V3-P2 tests for the atomic.Pointer[HotSnapshot]
+// copy-on-write replacement of the configMu.RLock snapshot path.
+//
+// These tests are gated behind the "testing" build tag so production builds
+// never include them (D-9 / ARCH-15). They live in package config (not
+// config_test) because Test_GetHotSnapshot_NilSafe must access the
+// package-level hotSnapshotPtr variable directly to verify the invariant
+// that it is never nil after resetConfig.
+package config
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/enum"
+)
+
+// Test_GetHotSnapshot_NilSafe asserts that hotSnapshotPtr is never nil after
+// resetConfig. A nil pointer would cause a nil-deref panic on every log call,
+// so this is a hard invariant for the atomic.Pointer[HotSnapshot] path.
+func Test_GetHotSnapshot_NilSafe(t *testing.T) {
+	TestResetConfig()
+	snap := hotSnapshotPtr.Load()
+	if snap == nil {
+		t.Fatal("hotSnapshotPtr.Load() must not be nil after resetConfig")
+	}
+}
+
+// Test_HotSnapshot_ConsistentWithSetTimeFormat asserts that after
+// SetTimeFormat, the atomic snapshot immediately reflects the new value —
+// without acquiring configMu. This verifies storeHotSnapshot is called
+// inside SetTimeFormat's lock scope.
+func Test_HotSnapshot_ConsistentWithSetTimeFormat(t *testing.T) {
+	TestResetConfig()
+	SetTimeFormat("2006-01-02")
+	snap := GetHotSnapshot()
+	if snap.TimeFormat != "2006-01-02" {
+		t.Fatalf("snapshot TimeFormat = %q, want %q", snap.TimeFormat, "2006-01-02")
+	}
+}
+
+// Test_HotSnapshot_ConsistentWithSetMinLevel asserts that after SetMinLevel the
+// atomic snapshot's TimeFormat still matches what GetConfig returns, and that
+// GetAtomicMinLevel reflects the new level. This verifies storeHotSnapshot is
+// called inside SetMinLevel's lock scope without corrupting other fields.
+func Test_HotSnapshot_ConsistentWithSetMinLevel(t *testing.T) {
+	TestResetConfig()
+	SetMinLevel(enum.LevelWarn)
+	snap := GetHotSnapshot()
+	cfg := GetConfig()
+	if snap.TimeFormat != cfg.TimeFormat() {
+		t.Fatalf("snapshot TimeFormat %q != config %q", snap.TimeFormat, cfg.TimeFormat())
+	}
+	if GetAtomicMinLevel() != enum.LevelWarn {
+		t.Fatalf("atomic min level not updated: got %v, want %v", GetAtomicMinLevel(), enum.LevelWarn)
+	}
+}
+
+// Test_HotSnapshot_ConsistentWithSetAddSource asserts that after SetAddSource,
+// the atomic snapshot reflects the new value without a configMu read.
+func Test_HotSnapshot_ConsistentWithSetAddSource(t *testing.T) {
+	t.Cleanup(func() { TestResetConfig() })
+	TestResetConfig()
+	SetAddSource(true)
+	snap := GetHotSnapshot()
+	if !snap.AddSource {
+		t.Fatal("snapshot AddSource = false, want true after SetAddSource(true)")
+	}
+	SetAddSource(false)
+	snap = GetHotSnapshot()
+	if snap.AddSource {
+		t.Fatal("snapshot AddSource = true, want false after SetAddSource(false)")
+	}
+}
+
+// Test_HotSnapshot_ConsistentWithSetEncoderType asserts that after
+// SetEncoderType, the atomic snapshot reflects the new encoder type.
+func Test_HotSnapshot_ConsistentWithSetEncoderType(t *testing.T) {
+	t.Cleanup(func() { TestResetConfig() })
+	TestResetConfig()
+	SetEncoderType(enum.EncoderText)
+	snap := GetHotSnapshot()
+	if snap.EncoderType != enum.EncoderText {
+		t.Fatalf("snapshot EncoderType = %v, want %v", snap.EncoderType, enum.EncoderText)
+	}
+}
+
+// Test_HotSnapshot_ConsistentWithSetContextFieldsParser asserts that after
+// SetContextFieldsParser, the atomic snapshot surfaces the new parser.
+func Test_HotSnapshot_ConsistentWithSetContextFieldsParser(t *testing.T) {
+	t.Cleanup(func() { TestResetConfig() })
+	TestResetConfig()
+	SetContextFieldsParser(func(_ context.Context) map[string]any {
+		return nil
+	})
+	// The snapshot stores a function pointer; we can only verify non-nil.
+	snap := GetHotSnapshot()
+	if snap.ContextParser == nil {
+		t.Fatal("snapshot ContextParser should be non-nil after SetContextFieldsParser")
+	}
+}
+
+// Test_HotSnapshot_ConsistentWithSetDefaultFields asserts that after
+// SetDefaultFields renames a key, the atomic snapshot's RestrictedFields map
+// contains the new name and the Rendered map has been rebuilt.
+func Test_HotSnapshot_ConsistentWithSetDefaultFields(t *testing.T) {
+	t.Cleanup(func() { TestResetConfig() })
+	TestResetConfig()
+	SetDefaultFields(map[enum.DefaultLogKey]string{
+		enum.DefaultLogKeyTime: "ts",
+	})
+	snap := GetHotSnapshot()
+	if _, ok := snap.RestrictedFields["ts"]; !ok {
+		t.Fatal("snapshot RestrictedFields should contain renamed key 'ts'")
+	}
+	if _, ok := snap.RestrictedFields["time"]; ok {
+		t.Fatal("snapshot RestrictedFields should NOT contain old key 'time' after rename")
+	}
+}
+
+// Test_HotSnapshot_NeverNilAfterEverySetterCalled asserts that after calling
+// every Set* mutator, hotSnapshotPtr is still non-nil and the snapshot has a
+// non-empty TimeFormat (a basic sanity sentinel for full snapshot integrity).
+func Test_HotSnapshot_NeverNilAfterEverySetterCalled(t *testing.T) {
+	t.Cleanup(func() { TestResetConfig() })
+	TestResetConfig()
+
+	SetTimeFormat("15:04:05")
+	SetMinLevel(enum.LevelDebug)
+	SetEncoderType(enum.EncoderJSON)
+	SetAddSource(false)
+	SetLogBufferMaxSize(50)
+	SetRate(2 * time.Second)
+	SetContextFieldsParser(nil)
+	SetContextFieldsAppender(nil)
+	SetDefaultFields(nil) // nil is a no-op per SetDefaultFields contract
+
+	ptr := hotSnapshotPtr.Load()
+	if ptr == nil {
+		t.Fatal("hotSnapshotPtr must not be nil after all setters called")
+	}
+	snap := GetHotSnapshot()
+	if snap.TimeFormat != "15:04:05" {
+		t.Fatalf("snapshot TimeFormat = %q, want %q", snap.TimeFormat, "15:04:05")
+	}
+}
+
+// Test_HotSnapshot_RaceWithSetters exercises concurrent writers and readers
+// against the atomic.Pointer[HotSnapshot] path. Under -race, any unsynchronised
+// access to hotSnapshotPtr would be reported as a DATA RACE.
+func Test_HotSnapshot_RaceWithSetters(t *testing.T) {
+	TestResetConfig()
+	t.Cleanup(func() { TestResetConfig() })
+
+	const goroutines = 4
+	const iterations = 500
+
+	done := make(chan struct{})
+	defer close(done)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			for j := 0; j < iterations; j++ {
+				SetTimeFormat("2006-01-02T15:04:05Z07:00")
+				SetMinLevel(enum.LevelDebug)
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			for j := 0; j < iterations; j++ {
+				_ = GetHotSnapshot()
+			}
+		}()
+	}
+}

--- a/config/atomic_snapshot_v3_bench_test.go
+++ b/config/atomic_snapshot_v3_bench_test.go
@@ -1,0 +1,26 @@
+//go:build testing
+
+// Package config contains the V3-P2 benchmark for the atomic.Pointer[HotSnapshot]
+// copy-on-write path. The benchmark defends the < 1 µs p99 SLO for the hot log
+// path and specifically targets the ~120 ns saving over the prior
+// configMu.RLock-based GetHotSnapshot (Epic V3 LLD §4.1).
+package config
+
+import "testing"
+
+// BenchmarkGetHotSnapshot measures the cost of a single GetHotSnapshot call via
+// the atomic.Pointer[HotSnapshot] path. Input: default config after TestResetConfig
+// (no context appender, JSON encoder). The p99 budget for this call is ≤ 20 ns/op
+// with 0 allocs/op — matching a single atomic.Pointer.Load plus struct dereference.
+//
+// why: the former configMu.RLock + struct copy path cost ~120-200 ns under
+// contention. atomic.Pointer.Load is a single memory barrier, eliminating lock
+// contention entirely on the read path (V3-P2 / LLD §4.1).
+func BenchmarkGetHotSnapshot(b *testing.B) {
+	TestResetConfig()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = GetHotSnapshot()
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,9 @@
 // acquire configMu (read). This satisfies the race-freedom requirement
 // tracked in issue #54 / story 039 without the allocation overhead of a
 // copy-on-write atomic.Pointer approach (see bench-baseline.txt for
-// the < 1 µs budget).
+// the < 1 µs budget). Hot-path booleans (HasEventPreProcessors) are
+// additionally mirrored into atomic.Bool fields so the most frequent
+// callers pay a single load instruction rather than a full RLock pair.
 package config
 
 import (
@@ -54,6 +56,18 @@ var (
 // on the filtered path removes ~200 ns of contention per filtered event,
 // keeping the overall call budget inside the < 1 µs SLO (Epic V2 / LLD §2.1).
 var atomicMinLevel atomic.Int64
+
+// hasPreProcessorsAtomic mirrors len(EventPreProcessors) > 0 as an atomic.Bool
+// so that HasEventPreProcessors can short-circuit without acquiring configMu.
+// It is stored inside configMu.Lock in every mutator (InitPreProcessors,
+// AddPreProcessors, RemovePreProcessor, resetConfig) to stay consistent with
+// the guarded map.
+//
+// why: the former RLock+RUnlock pair in HasEventPreProcessors cost ~80 ns on the
+// hot log path (V3-P1 / LLD §3.1). atomic.Bool.Load is a single memory barrier
+// with no scheduler interaction, bringing the check to < 1 ns/op (see
+// BenchmarkHasEventPreProcessors in preprocessor_gate_bench_test.go).
+var hasPreProcessorsAtomic atomic.Bool
 
 // Compile-time width guard: enum.LogLevel must fit in int64 so the atomic
 // store is lossless. If LogLevel ever widens beyond int64 this line will
@@ -254,6 +268,9 @@ func InitPreProcessors(observers ...preProcessingObserverContract) {
 	for _, observer := range observers {
 		EventPreProcessors[observer.Name()] = observer
 	}
+	// why: store inside the lock so HasEventPreProcessors sees a consistent value
+	// with respect to every other configMu writer (V3-P1 / LLD §3.1).
+	hasPreProcessorsAtomic.Store(len(EventPreProcessors) > 0)
 }
 
 // AddPreProcessors registers one or more pre-processors into the global
@@ -264,17 +281,22 @@ func AddPreProcessors(observers ...preProcessingObserverContract) {
 	for _, observer := range observers {
 		EventPreProcessors[observer.Name()] = observer
 	}
+	// why: store inside the lock so HasEventPreProcessors sees a consistent value
+	// with respect to every other configMu writer (V3-P1 / LLD §3.1).
+	hasPreProcessorsAtomic.Store(len(EventPreProcessors) > 0)
 }
 
 // HasEventPreProcessors reports whether at least one pre-processor is
-// registered. It acquires configMu.RLock so it is safe for concurrent use and
-// produces no data races. The hot path in logWithSkip calls this instead of
-// reading EventPreProcessors directly (which is an unsynchronised map access).
+// registered. It reads hasPreProcessorsAtomic with a single atomic load —
+// no lock is acquired — making it safe for concurrent use with zero contention
+// on the hot log path (V3-P1 / LLD §3.1).
+//
+// why: the former RLock+RUnlock pair cost ~80 ns per call; an atomic.Bool.Load
+// costs < 1 ns. The value is kept consistent by all mutators (InitPreProcessors,
+// AddPreProcessors, RemovePreProcessor, resetConfig) which store to
+// hasPreProcessorsAtomic inside their configMu.Lock sections.
 func HasEventPreProcessors() bool {
-	configMu.RLock()
-	n := len(EventPreProcessors)
-	configMu.RUnlock()
-	return n > 0
+	return hasPreProcessorsAtomic.Load()
 }
 
 // RemovePreProcessor deletes the named pre-processor from the global map.
@@ -283,6 +305,9 @@ func RemovePreProcessor(name string) {
 	configMu.Lock()
 	defer configMu.Unlock()
 	delete(EventPreProcessors, name)
+	// why: store inside the lock so HasEventPreProcessors sees a consistent value
+	// with respect to every other configMu writer (V3-P1 / LLD §3.1).
+	hasPreProcessorsAtomic.Store(len(EventPreProcessors) > 0)
 }
 
 // SetMinLevel sets the minimum log level for the logger. It stores the level
@@ -715,6 +740,11 @@ func resetConfig() {
 	ch = newCh
 	defaultConfig = newCfg
 	EventPreProcessors = make(map[string]preProcessingObserverContract)
+	// why: mirror the reset into the atomic so HasEventPreProcessors immediately
+	// observes false after TestResetConfig is called in tests (and at init).
+	// Without this store, the atomic would retain a stale true from a previous
+	// InitPreProcessors call across test resets (V3-P1 / LLD §3.1).
+	hasPreProcessorsAtomic.Store(false)
 	// why: restrictedFieldsSet must be rebuilt here so that
 	// ValidateandParseLogField works correctly from the very first call —
 	// even before any SetDefaultFields call is made. This is the fix for D-8:

--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,25 @@ var hasPreProcessorsAtomic atomic.Bool
 // so readers always observe a fully-initialised snapshot.
 var hotSnapshotPtr atomic.Pointer[HotSnapshot]
 
+// atomicCh holds the current dispatch channel as an atomic.Value so that
+// PublishLog can load the channel with a single memory barrier instead of
+// acquiring configMu.RLock and copying the pointer.
+//
+// Invariant: atomicCh must never be nil after package init. It is stored
+// inside every configMu.Lock scope in resetConfig (the only site that
+// creates a new channel) so readers always observe a valid, writable channel.
+//
+// why: the former configMu.RLock + pointer copy path in PublishLog cost ~50 ns
+// per hot-path call. atomic.Value.Load is a single memory barrier with no
+// scheduler interaction, eliminating lock contention on the send path entirely
+// and completing the V3 goal of zero RLock acquisitions on the hot log path
+// (V3-P3 / LLD §5.1 / bench-baseline.txt).
+//
+// Type discipline: only chan LogEvent values are ever stored; the Load cast
+// is guarded by the invariant above. A type mismatch panic would indicate a
+// programming error (wrong type stored), not a runtime condition.
+var atomicCh atomic.Value // stores chan LogEvent; written under configMu.Lock, read without lock
+
 // Compile-time width guard: enum.LogLevel must fit in int64 so the atomic
 // store is lossless. If LogLevel ever widens beyond int64 this line will
 // produce a compile error, not a silent data truncation.
@@ -419,15 +438,16 @@ func SetOutput(output io.Writer) {
 // returns. Data therefore has exclusive ownership; the background goroutine
 // (ProcessLogEvent) can read it safely without a defensive copy.
 //
-// why (lock discipline): the RLock is taken only for the pointer snapshot of
-// ch, not across the send itself. resetConfig never closes the old channel
-// (see comment there), so there is no "send on closed channel" risk.
-// Releasing the RLock before the send avoids holding it during a potentially
-// blocking channel operation.
+// why (V3-P3 lock elimination): the former configMu.RLock + pointer copy was
+// replaced by a single atomic.Value.Load on atomicCh. No lock is held during
+// either the load or the channel send, completing the V3 goal of zero RLock
+// acquisitions on the hot log path (~50 ns saving per call; see
+// BenchmarkPublishLog in atomic_channel_bench_test.go and bench-baseline.txt).
+// atomicCh is always stored inside configMu.Lock in resetConfig before any
+// goroutine can call PublishLog, so the Load always returns a valid channel
+// and the type assertion never panics under correct usage.
 func PublishLog(Level enum.LogLevel, Data []byte) {
-	configMu.RLock()
-	currentCh := ch
-	configMu.RUnlock()
+	currentCh := atomicCh.Load().(chan LogEvent)
 	currentCh <- LogEvent{
 		Level: Level,
 		Data:  Data,
@@ -804,6 +824,12 @@ func resetConfig() {
 
 	configMu.Lock()
 	ch = newCh
+	// why: atomicCh must be stored inside the same configMu.Lock scope as ch
+	// so that any concurrent PublishLog call that loads atomicCh always sees
+	// a channel that was created within the current configuration epoch. Storing
+	// outside the lock could allow a reader to load a stale channel while
+	// resetConfig has already replaced ch (V3-P3 / LLD §5.1).
+	atomicCh.Store(newCh)
 	defaultConfig = newCfg
 	EventPreProcessors = make(map[string]preProcessingObserverContract)
 	// why: mirror the reset into the atomic so HasEventPreProcessors immediately
@@ -834,12 +860,14 @@ func resetConfig() {
 	// why: the old channel is intentionally not closed here. resetConfig
 	// is a test-only path (called once from init at program start; the
 	// test shim TestResetConfig calls it in unit tests only). Closing the
-	// old channel while a concurrent PublishLog might still hold an RLock
-	// and be mid-send would require two-phase coordination that adds
-	// complexity beyond this story's scope. The pre-existing goroutine
-	// leak (old ProcessLogEvent blocking on the unreferenced channel) is
-	// a known trade-off tracked separately; it is harmless in test
-	// binaries which exit after the test run completes.
+	// old channel while a concurrent PublishLog might still be mid-send
+	// would require two-phase coordination that adds complexity beyond
+	// this story's scope (V3-P3 note: PublishLog no longer holds RLock,
+	// but a goroutine may be blocked on the send side of the old channel
+	// if it was pre-empted between Load and the send). The pre-existing
+	// goroutine leak (old ProcessLogEvent blocking on the unreferenced
+	// channel) is a known trade-off tracked separately; it is harmless in
+	// test binaries which exit after the test run completes.
 	go ProcessLogEvent()
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,20 @@ var atomicMinLevel atomic.Int64
 // BenchmarkHasEventPreProcessors in preprocessor_gate_bench_test.go).
 var hasPreProcessorsAtomic atomic.Bool
 
+// hotSnapshotPtr holds the current HotSnapshot as an atomic pointer so that
+// GetHotSnapshot can load the snapshot with a single memory barrier instead of
+// acquiring configMu.RLock and copying the struct field-by-field.
+//
+// why: the former configMu.RLock + struct copy path cost ~120-200 ns under
+// contention on the read side. atomic.Pointer.Load is a single instruction with
+// no scheduler interaction, making the read path allocation-free and
+// contention-free (V3-P2 / LLD §4.1 / ~120 ns saving per log event).
+//
+// Invariant: hotSnapshotPtr must never be nil after package init. It is stored
+// inside every configMu.Lock scope (in all Set* mutators and in resetConfig)
+// so readers always observe a fully-initialised snapshot.
+var hotSnapshotPtr atomic.Pointer[HotSnapshot]
+
 // Compile-time width guard: enum.LogLevel must fit in int64 so the atomic
 // store is lossless. If LogLevel ever widens beyond int64 this line will
 // produce a compile error, not a silent data truncation.
@@ -153,38 +167,51 @@ func GetAtomicMinLevel() enum.LogLevel {
 	return enum.LogLevel(atomicMinLevel.Load())
 }
 
-// GetHotSnapshot captures all hot-path config fields under a single
-// configMu.RLock and returns them as a HotSnapshot. The encoder's
-// OpenBytes and CloseBytes are fetched after the lock is released because
-// they return constant slices that never change after encoder construction.
+// storeHotSnapshot builds a fresh HotSnapshot from defaultConfig and
+// restrictedFieldsSet and atomically publishes it to hotSnapshotPtr.
 //
-// why: one RLock per log call replaces the 6+ individual RLock/RUnlock pairs
-// that existed when logWithSkip called GetConfig().AddSource(),
-// GetConfig().DefaultFields(), etc. separately. The reduction from ~1.2 µs
-// to ~200 µs lock overhead is measured in bench-baseline.txt (Epic V2 P1).
+// Precondition: caller must hold configMu (write lock). Calling this outside
+// the lock would allow a concurrent Set* writer to produce a snapshot that
+// mixes fields from two different writes, violating the atomic-visibility
+// guarantee (V3-P2 / LLD §4.1).
 //
-// Callers must not mutate any map field in the returned snapshot.
-func GetHotSnapshot() HotSnapshot {
-	configMu.RLock()
-	snap := HotSnapshot{
+// why: building the snapshot inside the lock ensures that every field in the
+// published pointer is consistent with respect to each other. Readers that
+// call GetHotSnapshot after the pointer is stored see a coherent snapshot
+// without ever acquiring configMu.
+func storeHotSnapshot() {
+	snap := &HotSnapshot{
 		AddSource:        defaultConfig.addSource,
 		TimeFormat:       defaultConfig.timeFormat,
-		DefaultFields:    defaultConfig.defaultFields,         // DO NOT MUTATE — shared reference
-		Rendered:         defaultConfig.defaultFieldsRendered, // DO NOT MUTATE — shared reference
+		DefaultFields:    defaultConfig.defaultFields,
+		Rendered:         defaultConfig.defaultFieldsRendered,
 		StaticFields:     defaultConfig.parsedStaticFields,
 		ContextParser:    defaultConfig.contextParser,
 		ContextAppender:  defaultConfig.contextAppender,
 		Encoder:          defaultConfig.encoderObj,
 		EncoderType:      defaultConfig.encoderType,
-		RestrictedFields: restrictedFieldsSet, // DO NOT MUTATE — shared reference
+		RestrictedFields: restrictedFieldsSet,
 	}
-	configMu.RUnlock()
-	// Call encoder methods outside the lock — they return package-level
-	// constant slices that are written once at encoder construction and
-	// never mutated.
+	// why: OpenBytes/CloseBytes return package-level constant slices written
+	// once at encoder construction and never mutated. They are safe to call
+	// inside the lock without risk of circular locking.
 	snap.EncoderOpen = snap.Encoder.OpenBytes()
 	snap.EncoderClose = snap.Encoder.CloseBytes()
-	return snap
+	hotSnapshotPtr.Store(snap)
+}
+
+// GetHotSnapshot returns the current hot-path config snapshot via a single
+// atomic.Pointer load. No lock is acquired; the returned value is a complete,
+// consistent snapshot published by the last Set* mutator or resetConfig call.
+//
+// why: replacing the former configMu.RLock + struct copy with a single
+// atomic.Pointer.Load removes ~120 ns of lock overhead per log event, the
+// largest single saving in Epic V3 (LLD §4.1 / bench-baseline.txt).
+//
+// Callers must treat every map field (DefaultFields, Rendered, RestrictedFields)
+// as read-only; they are shared references — do not mutate them.
+func GetHotSnapshot() HotSnapshot {
+	return *hotSnapshotPtr.Load()
 }
 
 // PublishLogMessageHookContract is the interface that log-level hooks must
@@ -313,25 +340,33 @@ func RemovePreProcessor(name string) {
 // SetMinLevel sets the minimum log level for the logger. It stores the level
 // both in defaultConfig (guarded by configMu) and in atomicMinLevel so that
 // the lock-free gate in GetAtomicMinLevel immediately observes the change.
+// storeHotSnapshot is called inside the lock so GetHotSnapshot immediately
+// reflects the new level on the atomic read path (V3-P2 / LLD §4.1).
 // Safe for concurrent use.
 func SetMinLevel(level enum.LogLevel) {
 	configMu.Lock()
 	defer configMu.Unlock()
 	defaultConfig.minLevel = level
 	atomicMinLevel.Store(int64(level))
+	storeHotSnapshot()
 }
 
-// SetTimeFormat sets the time format for log entries. Safe for
-// concurrent use.
+// SetTimeFormat sets the time format for log entries. storeHotSnapshot is
+// called inside the lock so the atomic snapshot immediately reflects the new
+// format without requiring callers to hold configMu (V3-P2 / LLD §4.1).
+// Safe for concurrent use.
 func SetTimeFormat(format string) {
 	configMu.Lock()
 	defer configMu.Unlock()
 	defaultConfig.timeFormat = format
+	storeHotSnapshot()
 }
 
 // SetEncoderType sets the encoder type for the logger. If the requested
-// encoder type is unknown, it falls back to EncoderJSON. Safe for
-// concurrent use.
+// encoder type is unknown, it falls back to EncoderJSON. storeHotSnapshot is
+// called inside the lock so the atomic snapshot immediately reflects the new
+// encoder and its OpenBytes/CloseBytes constants (V3-P2 / LLD §4.1).
+// Safe for concurrent use.
 func SetEncoderType(encoderType enum.LogEncodeType) {
 	var err error
 
@@ -345,18 +380,26 @@ func SetEncoderType(encoderType enum.LogEncodeType) {
 	}
 
 	defaultConfig.encoderType = encoderType
+	storeHotSnapshot()
 }
 
 // SetAddSource sets whether source file and line information is appended
-// to every log entry. Safe for concurrent use.
+// to every log entry. storeHotSnapshot is called inside the lock so the
+// atomic snapshot immediately reflects the new AddSource flag (V3-P2 / LLD §4.1).
+// Safe for concurrent use.
 func SetAddSource(addSource bool) {
 	configMu.Lock()
 	defer configMu.Unlock()
 	defaultConfig.addSource = addSource
+	storeHotSnapshot()
 }
 
 // SetOutput sets the output writer for the logger. A nil argument is
-// silently replaced with DefaultOutput. Safe for concurrent use.
+// silently replaced with DefaultOutput. output is not part of HotSnapshot
+// (it is accessed via GetConfig().Output() on the write path), but
+// storeHotSnapshot is called here for consistency so the snapshot remains
+// fully up-to-date with the rest of defaultConfig (V3-P2 / LLD §4.1).
+// Safe for concurrent use.
 func SetOutput(output io.Writer) {
 	if output == nil {
 		output = DefaultOutput
@@ -364,6 +407,7 @@ func SetOutput(output io.Writer) {
 	configMu.Lock()
 	defer configMu.Unlock()
 	defaultConfig.output = output
+	storeHotSnapshot()
 }
 
 // PublishLog sends Data onto the dispatch channel. Safe for concurrent use;
@@ -391,7 +435,10 @@ func PublishLog(Level enum.LogLevel, Data []byte) {
 }
 
 // SetLogBufferMaxSize sets the maximum buffer size for logs. Values ≤ 0
-// are silently replaced with 20. Safe for concurrent use.
+// are silently replaced with 20. storeHotSnapshot is called inside the lock
+// for consistency; logBufferMaxSize itself is not a HotSnapshot field but the
+// call keeps the snapshot fully synchronised with defaultConfig (V3-P2 / LLD §4.1).
+// Safe for concurrent use.
 func SetLogBufferMaxSize(size int) {
 	if size <= 0 {
 		size = 20 // Default buffer size
@@ -399,10 +446,14 @@ func SetLogBufferMaxSize(size int) {
 	configMu.Lock()
 	defer configMu.Unlock()
 	defaultConfig.logBufferMaxSize = size
+	storeHotSnapshot()
 }
 
 // SetRate sets the rate at which buffered logs are pushed to output.
-// Values ≤ 0 are silently replaced with 1 second. Safe for concurrent use.
+// Values ≤ 0 are silently replaced with 1 second. storeHotSnapshot is called
+// inside the lock for consistency; rate itself is not a HotSnapshot field but
+// the call keeps the snapshot fully synchronised with defaultConfig (V3-P2 / LLD §4.1).
+// Safe for concurrent use.
 func SetRate(rate time.Duration) {
 	if rate <= 0 {
 		rate = 1 * time.Second // Default rate is 1 sec
@@ -410,6 +461,7 @@ func SetRate(rate time.Duration) {
 	configMu.Lock()
 	defer configMu.Unlock()
 	defaultConfig.rate = rate
+	storeHotSnapshot()
 }
 
 // restrictedFieldsSet is the O(1) replacement for the former restrictedFields
@@ -502,7 +554,9 @@ func ParseLogField(key string, value any) string {
 
 // SetStaticEnvFieldsParser sets the function that extracts static
 // environment fields merged into every log line. Passing nil clears the
-// field. Safe for concurrent use.
+// field. storeHotSnapshot is called inside the lock so the atomic snapshot
+// immediately reflects the new StaticFields fragment (V3-P2 / LLD §4.1).
+// Safe for concurrent use.
 func SetStaticEnvFieldsParser(parser StaticEnvFieldsParser) {
 	var parsed string
 	if parser != nil {
@@ -517,24 +571,31 @@ func SetStaticEnvFieldsParser(parser StaticEnvFieldsParser) {
 	configMu.Lock()
 	defer configMu.Unlock()
 	defaultConfig.parsedStaticFields = parsed
+	storeHotSnapshot()
 }
 
 // SetContextFieldsParser sets the function that extracts per-request
-// context fields. Safe for concurrent use.
+// context fields. storeHotSnapshot is called inside the lock so the atomic
+// snapshot immediately reflects the new ContextParser (V3-P2 / LLD §4.1).
+// Safe for concurrent use.
 func SetContextFieldsParser(parser ContextFieldsParser) {
 	configMu.Lock()
 	defer configMu.Unlock()
 	defaultConfig.contextParser = parser
+	storeHotSnapshot()
 }
 
 // SetContextFieldsAppender sets the zero-alloc context field writer.
 // When set, it takes precedence over any ContextFieldsParser on the hot path.
 // The appender receives the entry buffer and must append ,key:value fragments
-// for each context field, returning the extended buffer. Safe for concurrent use.
+// for each context field, returning the extended buffer. storeHotSnapshot is
+// called inside the lock so the atomic snapshot immediately reflects the new
+// ContextAppender (V3-P2 / LLD §4.1). Safe for concurrent use.
 func SetContextFieldsAppender(appender ContextFieldsAppender) {
 	configMu.Lock()
 	defer configMu.Unlock()
 	defaultConfig.contextAppender = appender
+	storeHotSnapshot()
 }
 
 // SetChannelCapacity sets the buffer size for the dispatch channel created by
@@ -620,6 +681,11 @@ func SetDefaultFields(fields map[enum.DefaultLogKey]string) {
 	// under the same write lock to keep restrictedFieldsSet and
 	// defaultFieldsRendered consistent (ARCH-6 / acceptance criterion 3).
 	defaultConfig.defaultFieldsRendered = buildRenderedFields(defaultConfig.defaultFields)
+	// why: storeHotSnapshot must be called after both buildRestrictedSet and
+	// buildRenderedFields so the published snapshot contains the fully-rebuilt
+	// maps. A snapshot stored before either rebuild would expose stale map
+	// references to concurrent readers on the atomic path (V3-P2 / LLD §4.1).
+	storeHotSnapshot()
 }
 
 // GetConfig returns a pointer to the current logger configuration.
@@ -757,6 +823,12 @@ func resetConfig() {
 	// tests (and at init). Without this store, the atomic would retain a
 	// stale value from a previous SetMinLevel call across test resets.
 	atomicMinLevel.Store(int64(newCfg.minLevel))
+	// why: storeHotSnapshot must be called after defaultConfig, restrictedFieldsSet,
+	// and atomicMinLevel are all written, so the published pointer contains a
+	// fully-consistent reset snapshot. Readers that call GetHotSnapshot after
+	// configMu.Unlock() will see the reset state without ever acquiring the lock
+	// (V3-P2 / LLD §4.1 / Test_GetHotSnapshot_NilSafe).
+	storeHotSnapshot()
 	configMu.Unlock()
 
 	// why: the old channel is intentionally not closed here. resetConfig

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -83,24 +84,19 @@ var hasPreProcessorsAtomic atomic.Bool
 // so readers always observe a fully-initialised snapshot.
 var hotSnapshotPtr atomic.Pointer[HotSnapshot]
 
-// atomicCh holds the current dispatch channel as an atomic.Value so that
-// PublishLog can load the channel with a single memory barrier instead of
-// acquiring configMu.RLock and copying the pointer.
+// atomicRing holds the current MPSC ring buffer as an atomic pointer so that
+// PublishLog can enqueue events with a single memory barrier and a lock-free
+// Push, with no configMu acquisition on the hot path (V3-P9 / LLD §5.1).
 //
-// Invariant: atomicCh must never be nil after package init. It is stored
+// Invariant: atomicRing must never be nil after package init. It is stored
 // inside every configMu.Lock scope in resetConfig (the only site that
-// creates a new channel) so readers always observe a valid, writable channel.
-//
-// why: the former configMu.RLock + pointer copy path in PublishLog cost ~50 ns
-// per hot-path call. atomic.Value.Load is a single memory barrier with no
-// scheduler interaction, eliminating lock contention on the send path entirely
-// and completing the V3 goal of zero RLock acquisitions on the hot log path
-// (V3-P3 / LLD §5.1 / bench-baseline.txt).
-//
-// Type discipline: only chan LogEvent values are ever stored; the Load cast
-// is guarded by the invariant above. A type mismatch panic would indicate a
-// programming error (wrong type stored), not a runtime condition.
-var atomicCh atomic.Value // stores chan LogEvent; written under configMu.Lock, read without lock
+// creates a new ring) so callers of PublishLog always observe a valid ring.
+var atomicRing atomic.Pointer[mpscRingBuffer]
+
+// ringDoneCh is closed by resetConfig to signal the current ProcessLogEvent
+// goroutine to stop spinning and exit. A new channel is allocated for each
+// new ring epoch. Protected by configMu.Lock when replaced.
+var ringDoneCh chan struct{}
 
 // Compile-time width guard: enum.LogLevel must fit in int64 so the atomic
 // store is lossless. If LogLevel ever widens beyond int64 this line will
@@ -284,18 +280,15 @@ type LogEvent struct {
 
 var (
 	defaultConfig      *Config
-	ch                 chan LogEvent
 	EventPreProcessors map[string]preProcessingObserverContract
 
-	// configMu guards the three package-level globals above.
+	// configMu guards defaultConfig, EventPreProcessors, and the ring epoch.
 	//
-	// why: ProcessLogEvent reads ch and EventPreProcessors concurrently
-	// with resetConfig writing them; Set* functions write fields of
-	// defaultConfig concurrently with each other and with resetConfig.
-	// A single RWMutex is the minimal, reviewable fix for #54.
-	// RLock is taken by read-only paths (GetConfig, ProcessLogEvent) so
-	// multiple concurrent readers never block each other; write paths
-	// (Set*, resetConfig) take the exclusive Lock.
+	// why: ProcessLogEvent reads EventPreProcessors concurrently with
+	// resetConfig writing them; Set* functions write fields of defaultConfig
+	// concurrently with each other and with resetConfig. A single RWMutex is
+	// the minimal, reviewable fix for #54. RLock is taken by read-only paths;
+	// write paths (Set*, resetConfig) take the exclusive Lock.
 	configMu sync.RWMutex
 )
 
@@ -438,20 +431,14 @@ func SetOutput(output io.Writer) {
 // returns. Data therefore has exclusive ownership; the background goroutine
 // (ProcessLogEvent) can read it safely without a defensive copy.
 //
-// why (V3-P3 lock elimination): the former configMu.RLock + pointer copy was
-// replaced by a single atomic.Value.Load on atomicCh. No lock is held during
-// either the load or the channel send, completing the V3 goal of zero RLock
-// acquisitions on the hot log path (~50 ns saving per call; see
-// BenchmarkPublishLog in atomic_channel_bench_test.go and bench-baseline.txt).
-// atomicCh is always stored inside configMu.Lock in resetConfig before any
-// goroutine can call PublishLog, so the Load always returns a valid channel
-// and the type assertion never panics under correct usage.
+// why (V3-P9 ring buffer): the channel send (~130 ns under 8-goroutine
+// contention) is replaced by an atomic.Pointer load + lock-free Push on the
+// MPSC ring buffer. Multiple producers write concurrently via fetch-and-add
+// on the ring tail; no mutex is held on the hot path. atomicRing is always
+// stored inside configMu.Lock in resetConfig so the load always returns a
+// valid ring (V3-P9 / LLD §5.1).
 func PublishLog(Level enum.LogLevel, Data []byte) {
-	currentCh := atomicCh.Load().(chan LogEvent)
-	currentCh <- LogEvent{
-		Level: Level,
-		Data:  Data,
-	}
+	atomicRing.Load().Push(LogEvent{Level: Level, Data: Data})
 }
 
 // SetLogBufferMaxSize sets the maximum buffer size for logs. Values ≤ 0
@@ -618,10 +605,10 @@ func SetContextFieldsAppender(appender ContextFieldsAppender) {
 	storeHotSnapshot()
 }
 
-// SetChannelCapacity sets the buffer size for the dispatch channel created by
-// the next resetConfig call. Must be called before init() fires (Go
-// init-ordering guarantee) and before InitPreProcessors. No configMu needed —
-// the variable is written once at startup, read once in resetConfig.
+// SetChannelCapacity is retained for API compatibility. Since V3-P9 replaced
+// the buffered chan LogEvent with a fixed-size MPSC ring buffer (ringSize=4096),
+// this value is no longer used by the dispatch path and has no effect on
+// throughput or backpressure. It is safe to call but does nothing observable.
 //
 // Values ≤ 0 are clamped to DafaultLogBuffer (1000); values > 100_000 are
 // clamped to 100_000. A log.Printf warning is emitted for out-of-range values.
@@ -717,24 +704,49 @@ func GetConfig() *Config {
 	return defaultConfig
 }
 
-// ProcessLogEvent drains the dispatch channel and forwards each event
-// to every registered PreProcessor. It is started as a goroutine by
-// resetConfig and runs until the channel is closed. Safe for concurrent
-// use: it takes an RLock to snapshot the current ch and EventPreProcessors
-// values so that a concurrent resetConfig does not create a data race on
-// those globals.
+// ProcessLogEvent pops events from the MPSC ring buffer and forwards each to
+// every registered PreProcessor. It runs until ringDoneCh is closed (by the
+// next resetConfig call). On an empty ring it yields the goroutine with
+// runtime.Gosched rather than blocking, then rechecks the done signal. When
+// done is signalled the remaining ring items are drained before returning.
+//
+// why (V3-P9): replacing the channel range with a lock-free ring Pop removes
+// the channel mutex from the consumer hot path, completing the V3 sub-500 ns
+// target.
 func ProcessLogEvent() {
 	configMu.RLock()
-	currentCh := ch
+	currentRing := atomicRing.Load()
+	done := ringDoneCh
 	configMu.RUnlock()
 
-	for e := range currentCh {
-		configMu.RLock()
-		processors := EventPreProcessors
-		configMu.RUnlock()
-		for _, observer := range processors {
-			observer.PreProcess(e.Level, e.Data)
+	for {
+		e, ok := currentRing.Pop()
+		if !ok {
+			select {
+			case <-done:
+				// Drain any events written between the last Pop and the done signal.
+				for currentRing.Len() > 0 {
+					if ev, ok2 := currentRing.Pop(); ok2 {
+						dispatchEvent(ev)
+					}
+				}
+				return
+			default:
+				runtime.Gosched()
+				continue
+			}
 		}
+		dispatchEvent(e)
+	}
+}
+
+// dispatchEvent forwards e to every registered PreProcessor under a short RLock.
+func dispatchEvent(e LogEvent) {
+	configMu.RLock()
+	processors := EventPreProcessors
+	configMu.RUnlock()
+	for _, observer := range processors {
+		observer.PreProcess(e.Level, e.Data)
 	}
 }
 
@@ -752,9 +764,10 @@ func ProcessLogEvent() {
 // The old channel is closed after the pointer swap so the previous
 // ProcessLogEvent goroutine exits cleanly rather than leaking.
 func resetConfig() {
-	// Build the new config and channel before acquiring the lock to
-	// minimise lock-hold time — encoder factory can take allocations.
-	newCh := make(chan LogEvent, int(channelCapacity.Load()))
+	// Build the new ring buffer, done channel, and config before acquiring the
+	// lock to minimise lock-hold time — encoder factory can take allocations.
+	newRing := newMpscRingBuffer()
+	newDoneCh := make(chan struct{})
 	encoderObj := encoder.DefaultEncoderFactory(enum.EncoderJSON)
 	newCfg := &Config{
 		minLevel:           DafaultLevel,
@@ -822,14 +835,15 @@ func resetConfig() {
 	// is not yet visible to any other goroutine at this point.
 	newCfg.defaultFieldsRendered = buildRenderedFields(newCfg.defaultFields)
 
+	var oldDoneCh chan struct{}
 	configMu.Lock()
-	ch = newCh
-	// why: atomicCh must be stored inside the same configMu.Lock scope as ch
-	// so that any concurrent PublishLog call that loads atomicCh always sees
-	// a channel that was created within the current configuration epoch. Storing
-	// outside the lock could allow a reader to load a stale channel while
-	// resetConfig has already replaced ch (V3-P3 / LLD §5.1).
-	atomicCh.Store(newCh)
+	// why: atomicRing must be stored inside configMu.Lock so that any concurrent
+	// PublishLog that loads atomicRing always sees a ring from the current epoch.
+	// Storing outside the lock could let a reader load the stale ring while
+	// resetConfig has already replaced it (V3-P9 / LLD §5.1).
+	atomicRing.Store(newRing)
+	oldDoneCh = ringDoneCh
+	ringDoneCh = newDoneCh
 	defaultConfig = newCfg
 	EventPreProcessors = make(map[string]preProcessingObserverContract)
 	// why: mirror the reset into the atomic so HasEventPreProcessors immediately
@@ -857,17 +871,12 @@ func resetConfig() {
 	storeHotSnapshot()
 	configMu.Unlock()
 
-	// why: the old channel is intentionally not closed here. resetConfig
-	// is a test-only path (called once from init at program start; the
-	// test shim TestResetConfig calls it in unit tests only). Closing the
-	// old channel while a concurrent PublishLog might still be mid-send
-	// would require two-phase coordination that adds complexity beyond
-	// this story's scope (V3-P3 note: PublishLog no longer holds RLock,
-	// but a goroutine may be blocked on the send side of the old channel
-	// if it was pre-empted between Load and the send). The pre-existing
-	// goroutine leak (old ProcessLogEvent blocking on the unreferenced
-	// channel) is a known trade-off tracked separately; it is harmless in
-	// test binaries which exit after the test run completes.
+	// Close the old ringDoneCh (outside the lock) to signal the previous
+	// ProcessLogEvent goroutine to drain and exit. nil on the very first call
+	// from init (before any goroutine has started).
+	if oldDoneCh != nil {
+		close(oldDoneCh)
+	}
 	go ProcessLogEvent()
 }
 

--- a/config/level_bytes_bench_test.go
+++ b/config/level_bytes_bench_test.go
@@ -1,0 +1,20 @@
+//go:build testing
+
+package config
+
+import (
+	"testing"
+
+	"github.com/architagr/lognugget/enum"
+)
+
+// BenchmarkAppendQuotedLevel_Named measures the pre-rendered fast path (no
+// level.String() call, no allocation).
+func BenchmarkAppendQuotedLevel_Named(b *testing.B) {
+	dst := make([]byte, 0, 16)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dst = AppendQuotedLevel(dst[:0], enum.LevelInfo)
+	}
+}

--- a/config/level_bytes_test.go
+++ b/config/level_bytes_test.go
@@ -1,0 +1,68 @@
+//go:build testing
+
+package config
+
+import (
+	"testing"
+
+	"github.com/architagr/lognugget/enum"
+)
+
+func Test_AppendQuotedLevel_NamedLevels(t *testing.T) {
+	cases := []struct {
+		level enum.LogLevel
+		want  string
+	}{
+		{enum.LevelDebug, `"DEBUG"`},
+		{enum.LevelInfo, `"INFO"`},
+		{enum.LevelWarn, `"WARN"`},
+		{enum.LevelError, `"ERROR"`},
+		{enum.LevelFatal, `"FATAL"`},
+	}
+	for _, c := range cases {
+		got := string(AppendQuotedLevel(nil, c.level))
+		if got != c.want {
+			t.Errorf("level %v: got %s, want %s", c.level, got, c.want)
+		}
+	}
+}
+
+// Test_AppendQuotedLevel_NoAlloc verifies named levels produce no heap allocations
+// (they append pre-quoted byte literals, bypassing level.String()).
+func Test_AppendQuotedLevel_NoAlloc(t *testing.T) {
+	named := []enum.LogLevel{
+		enum.LevelDebug, enum.LevelInfo, enum.LevelWarn, enum.LevelError, enum.LevelFatal,
+	}
+	dst := make([]byte, 0, 16)
+	for _, l := range named {
+		allocs := testing.AllocsPerRun(100, func() {
+			dst = AppendQuotedLevel(dst[:0], l)
+		})
+		if allocs != 0 {
+			t.Errorf("level %v: got %.0f allocs, want 0", l, allocs)
+		}
+	}
+}
+
+// Test_AppendQuotedLevel_UnknownLevel verifies that a level value not in the
+// switch falls back to AppendQuotedString without panicking and produces a
+// valid quoted JSON string.
+func Test_AppendQuotedLevel_UnknownLevel(t *testing.T) {
+	unknown := enum.LogLevel(99)
+	got := string(AppendQuotedLevel(nil, unknown))
+	// Must be a quoted, non-empty string — exact value depends on LogLevel.String().
+	if len(got) < 2 || got[0] != '"' || got[len(got)-1] != '"' {
+		t.Errorf("unknown level fallback produced invalid JSON string: %s", got)
+	}
+}
+
+// Test_AppendQuotedLevel_AppendToExisting verifies AppendQuotedLevel correctly
+// appends to a non-nil dst rather than overwriting it.
+func Test_AppendQuotedLevel_AppendToExisting(t *testing.T) {
+	prefix := []byte(`"level":`)
+	got := string(AppendQuotedLevel(append([]byte(nil), prefix...), enum.LevelInfo))
+	want := `"level":"INFO"`
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}

--- a/config/parse_field.go
+++ b/config/parse_field.go
@@ -9,6 +9,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/architagr/lognugget/enum"
 	"github.com/architagr/lognugget/model"
 )
 
@@ -26,13 +27,16 @@ func AppendQuotedString(dst []byte, s string) []byte {
 	return appendJSONStringStr(dst, s)
 }
 
-// appendJSONStringStr appends s to dst as an RFC 8259 JSON string. Operates
-// directly on the string header — no []byte(s) allocation on the hot path.
-// Invalid UTF-8 bytes are replaced with U+FFFD, matching appendJSONString.
+// appendJSONStringStr appends s to dst as an RFC 8259 JSON string (including
+// the surrounding double-quote characters). It operates directly on the string
+// header, avoiding the []byte(s) allocation that appendJSONString incurs.
+// Invalid UTF-8 bytes are replaced with the Unicode replacement character
+// (U+FFFD), matching appendJSONString semantics exactly.
 //
-// why: []byte(s) allocates a copy for every call (~20 ns, ~2 allocs/event).
-// Indexing the string directly via utf8.DecodeRuneInString eliminates that
-// alloc while preserving identical escape semantics (V3-P5 / issue #116).
+// why: []byte(s) allocates a copy on the heap for every call on the hot log
+// path (~20 ns, ~2 allocs/event). Operating on the string directly via
+// utf8.DecodeRuneInString and direct byte indexing eliminates that allocation
+// while keeping identical escape behaviour (V3-P5).
 func appendJSONStringStr(dst []byte, s string) []byte {
 	dst = append(dst, '"')
 	for i := 0; i < len(s); {
@@ -159,6 +163,33 @@ func init() {
 	cfgEscapeTable['\t'] = cfgEscT
 }
 
+// AppendQuotedLevel appends the JSON-quoted representation of l to dst and
+// returns the extended slice. Named levels (Debug, Info, Warn, Error, Fatal)
+// append pre-quoted constant byte slices — zero heap allocations. Unknown
+// levels fall back to AppendQuotedString(l.String()), which allocates.
+//
+// Safe for concurrent use; reads no shared state.
+//
+// why: level.String() allocates a string on every call; switching over the
+// five named constants and appending literal bytes eliminates ~1 alloc and
+// ~15 ns per log event on the hot path (V3-P6 / story #117).
+func AppendQuotedLevel(dst []byte, l enum.LogLevel) []byte {
+	switch l {
+	case enum.LevelDebug:
+		return append(dst, `"DEBUG"`...)
+	case enum.LevelInfo:
+		return append(dst, `"INFO"`...)
+	case enum.LevelWarn:
+		return append(dst, `"WARN"`...)
+	case enum.LevelError:
+		return append(dst, `"ERROR"`...)
+	case enum.LevelFatal:
+		return append(dst, `"FATAL"`...)
+	default:
+		return AppendQuotedString(dst, l.String())
+	}
+}
+
 // AppendField appends a JSON key-value fragment of the form `"key":value` to
 // dst and returns the extended slice. dst may be nil; a new slice is allocated
 // in that case.
@@ -262,12 +293,12 @@ func AppendField(dst []byte, key string, value any) []byte {
 // AppendAttr is safe for concurrent use; it reads no shared state.
 func AppendAttr(dst []byte, key string, attr model.LogAttr) []byte {
 	// Write the key as a quoted, RFC 8259 escaped JSON string.
-	dst = appendJSONStringStr(dst, key)
+	dst = appendJSONString(dst, []byte(key))
 	dst = append(dst, ':')
 
 	switch attr.Kind() {
 	case model.KindStr:
-		dst = appendJSONStringStr(dst, attr.StrVal())
+		dst = appendJSONString(dst, []byte(attr.StrVal()))
 
 	case model.KindInt:
 		dst = strconv.AppendInt(dst, attr.IntVal(), 10)
@@ -294,7 +325,7 @@ func AppendAttr(dst []byte, key string, attr model.LogAttr) []byte {
 		// call sites. New callers should use the typed constructors.
 		switch v := attr.Value.(type) {
 		case string:
-			dst = appendJSONStringStr(dst, v)
+			dst = appendJSONString(dst, []byte(v))
 		case int:
 			dst = strconv.AppendInt(dst, int64(v), 10)
 		case int8:

--- a/config/parse_field.go
+++ b/config/parse_field.go
@@ -23,7 +23,55 @@ import (
 //
 // Safe for concurrent use; reads no shared state.
 func AppendQuotedString(dst []byte, s string) []byte {
-	return appendJSONString(dst, []byte(s))
+	return appendJSONStringStr(dst, s)
+}
+
+// appendJSONStringStr appends s to dst as an RFC 8259 JSON string. Operates
+// directly on the string header — no []byte(s) allocation on the hot path.
+// Invalid UTF-8 bytes are replaced with U+FFFD, matching appendJSONString.
+//
+// why: []byte(s) allocates a copy for every call (~20 ns, ~2 allocs/event).
+// Indexing the string directly via utf8.DecodeRuneInString eliminates that
+// alloc while preserving identical escape semantics (V3-P5 / issue #116).
+func appendJSONStringStr(dst []byte, s string) []byte {
+	dst = append(dst, '"')
+	for i := 0; i < len(s); {
+		b := s[i]
+		if b >= utf8.RuneSelf {
+			r, size := utf8.DecodeRuneInString(s[i:])
+			if r == utf8.RuneError && size == 1 {
+				dst = append(dst, '\xef', '\xbf', '\xbd') // U+FFFD replacement
+				i++
+				continue
+			}
+			dst = append(dst, s[i:i+size]...)
+			i += size
+			continue
+		}
+		switch cfgEscapeTable[b] {
+		case 0:
+			dst = append(dst, b)
+		case cfgEscHex:
+			dst = append(dst, '\\', 'u', '0', '0', cfgHexDigits[b>>4], cfgHexDigits[b&0xf])
+		case cfgEscQuot:
+			dst = append(dst, '\\', '"')
+		case cfgEscBksl:
+			dst = append(dst, '\\', '\\')
+		case cfgEscB:
+			dst = append(dst, '\\', 'b')
+		case cfgEscF:
+			dst = append(dst, '\\', 'f')
+		case cfgEscN:
+			dst = append(dst, '\\', 'n')
+		case cfgEscR:
+			dst = append(dst, '\\', 'r')
+		case cfgEscT:
+			dst = append(dst, '\\', 't')
+		}
+		i++
+	}
+	dst = append(dst, '"')
+	return dst
 }
 
 // appendJSONString appends src to dst as an RFC 8259 JSON string (including the
@@ -135,12 +183,12 @@ func init() {
 // AppendField is safe for concurrent use; it reads no shared state.
 func AppendField(dst []byte, key string, value any) []byte {
 	// Write the key as a quoted, RFC 8259 escaped JSON string.
-	dst = appendJSONString(dst, []byte(key))
+	dst = appendJSONStringStr(dst, key)
 	dst = append(dst, ':')
 
 	switch v := value.(type) {
 	case string:
-		dst = appendJSONString(dst, []byte(v))
+		dst = appendJSONStringStr(dst, v)
 
 	case int:
 		dst = strconv.AppendInt(dst, int64(v), 10)
@@ -214,12 +262,12 @@ func AppendField(dst []byte, key string, value any) []byte {
 // AppendAttr is safe for concurrent use; it reads no shared state.
 func AppendAttr(dst []byte, key string, attr model.LogAttr) []byte {
 	// Write the key as a quoted, RFC 8259 escaped JSON string.
-	dst = appendJSONString(dst, []byte(key))
+	dst = appendJSONStringStr(dst, key)
 	dst = append(dst, ':')
 
 	switch attr.Kind() {
 	case model.KindStr:
-		dst = appendJSONString(dst, []byte(attr.StrVal()))
+		dst = appendJSONStringStr(dst, attr.StrVal())
 
 	case model.KindInt:
 		dst = strconv.AppendInt(dst, attr.IntVal(), 10)
@@ -246,7 +294,7 @@ func AppendAttr(dst []byte, key string, attr model.LogAttr) []byte {
 		// call sites. New callers should use the typed constructors.
 		switch v := attr.Value.(type) {
 		case string:
-			dst = appendJSONString(dst, []byte(v))
+			dst = appendJSONStringStr(dst, v)
 		case int:
 			dst = strconv.AppendInt(dst, int64(v), 10)
 		case int8:

--- a/config/preprocessor_gate_bench_test.go
+++ b/config/preprocessor_gate_bench_test.go
@@ -1,0 +1,26 @@
+//go:build testing
+
+// Package config_test provides benchmarks for the atomic preprocessor gate (V3-P1).
+package config_test
+
+import (
+	"testing"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/test/support"
+)
+
+// BenchmarkHasEventPreProcessors measures the hot-path cost of HasEventPreProcessors
+// after the V3-P1 atomic.Bool optimisation. Input: one registered processor (the
+// realistic steady state). p99 must stay <= 5 ns/op with 0 allocs/op;
+// the sub-1 µs budget from CLAUDE.md gives us ample headroom.
+func BenchmarkHasEventPreProcessors(b *testing.B) {
+	config.TestResetConfig()
+	fp := support.NewFakePreProc("p1")
+	config.InitPreProcessors(fp)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = config.HasEventPreProcessors()
+	}
+}

--- a/config/preprocessor_gate_test.go
+++ b/config/preprocessor_gate_test.go
@@ -1,0 +1,107 @@
+//go:build testing
+
+// Package config_test verifies the atomic preprocessor gate introduced in V3-P1.
+// These tests exercise HasEventPreProcessors, InitPreProcessors, AddPreProcessors,
+// and RemovePreProcessor to verify the atomic.Bool mirrors map state correctly
+// under concurrent access.
+package config_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/test/support"
+)
+
+// Test_HasPreProcessors_FalseOnEmpty asserts that HasEventPreProcessors returns
+// false when InitPreProcessors is called with no arguments.
+func Test_HasPreProcessors_FalseOnEmpty(t *testing.T) {
+	t.Cleanup(func() { config.TestResetConfig() })
+	config.TestResetConfig()
+	config.InitPreProcessors()
+	if config.HasEventPreProcessors() {
+		t.Fatal("expected false for empty processor set")
+	}
+}
+
+// Test_HasPreProcessors_TrueAfterInit asserts that HasEventPreProcessors returns
+// true after InitPreProcessors is called with at least one processor.
+func Test_HasPreProcessors_TrueAfterInit(t *testing.T) {
+	t.Cleanup(func() { config.TestResetConfig() })
+	config.TestResetConfig()
+	fp := support.NewFakePreProc("p1")
+	config.InitPreProcessors(fp)
+	if !config.HasEventPreProcessors() {
+		t.Fatal("expected true after InitPreProcessors with one processor")
+	}
+}
+
+// Test_HasPreProcessors_FalseAfterRemove asserts that HasEventPreProcessors returns
+// false after the last processor is removed via RemovePreProcessor.
+func Test_HasPreProcessors_FalseAfterRemove(t *testing.T) {
+	t.Cleanup(func() { config.TestResetConfig() })
+	config.TestResetConfig()
+	fp := support.NewFakePreProc("p1")
+	config.InitPreProcessors(fp)
+	config.RemovePreProcessor(fp.Name())
+	if config.HasEventPreProcessors() {
+		t.Fatal("expected false after removing last processor")
+	}
+}
+
+// Test_HasPreProcessors_TrueAfterAdd asserts that HasEventPreProcessors returns
+// true after a processor is registered via AddPreProcessors.
+func Test_HasPreProcessors_TrueAfterAdd(t *testing.T) {
+	t.Cleanup(func() { config.TestResetConfig() })
+	config.TestResetConfig()
+	fp := support.NewFakePreProc("p1")
+	config.AddPreProcessors(fp)
+	if !config.HasEventPreProcessors() {
+		t.Fatal("expected true after AddPreProcessors")
+	}
+}
+
+// Test_HasPreProcessors_FalseAfterReset asserts that HasEventPreProcessors returns
+// false immediately after TestResetConfig clears all state.
+func Test_HasPreProcessors_FalseAfterReset(t *testing.T) {
+	t.Cleanup(func() { config.TestResetConfig() })
+	config.TestResetConfig()
+	fp := support.NewFakePreProc("p1")
+	config.InitPreProcessors(fp)
+	config.TestResetConfig()
+	if config.HasEventPreProcessors() {
+		t.Fatal("expected false after TestResetConfig")
+	}
+}
+
+// Test_HasPreProcessors_Race verifies that concurrent adds, removes, and reads
+// of HasEventPreProcessors produce no data races under -race. Four goroutines
+// repeatedly add and remove a processor while four readers poll HasEventPreProcessors.
+func Test_HasPreProcessors_Race(t *testing.T) {
+	t.Cleanup(func() { config.TestResetConfig() })
+	config.TestResetConfig()
+	fp := support.NewFakePreProc("p1")
+	config.InitPreProcessors(fp)
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				config.AddPreProcessors(support.NewFakePreProc("tmp"))
+				config.RemovePreProcessor("tmp")
+			}
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				_ = config.HasEventPreProcessors()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/config/ring_buffer.go
+++ b/config/ring_buffer.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"runtime"
+	"sync/atomic"
+)
+
+const (
+	ringSize = 4096
+	ringMask = uint64(ringSize - 1)
+)
+
+// ringSlot is one entry in the MPSC ring buffer. Each slot is padded to a
+// single cache line (64 bytes) to eliminate false sharing between adjacent
+// slots accessed by different producer goroutines.
+//
+// Layout on amd64/arm64:
+//
+//	seq  atomic.Uint64 = 8 bytes
+//	data LogEvent       = 32 bytes (Level int64=8 + Data []byte=24)
+//	_    [24]byte       = padding
+//	total               = 64 bytes (1 cache line)
+type ringSlot struct {
+	seq  atomic.Uint64
+	data LogEvent
+	_    [24]byte // cache-line padding
+}
+
+// mpscRingBuffer is a bounded, lock-free multiple-producer single-consumer
+// queue following the Dmitry Vyukov MPSC ring buffer pattern. Producers call
+// Push concurrently; the consumer calls Pop from a single goroutine only.
+//
+// Each field group is padded to its own cache line to prevent the producers'
+// tail pointer from interfering with the consumer's head pointer.
+type mpscRingBuffer struct {
+	_pad0 [64]byte      // isolate from adjacent heap objects
+	tail  atomic.Uint64 // fetch-and-add by producers
+	_pad1 [56]byte      // pad tail to its own 64-byte cache line
+	head  atomic.Uint64 // load/store by the consumer only
+	_pad2 [56]byte      // pad head to its own 64-byte cache line
+	slots [ringSize]ringSlot
+}
+
+// newMpscRingBuffer allocates and initialises an mpscRingBuffer. Each slot's
+// seq is set to its index, marking all slots as available for the first round
+// of producers.
+func newMpscRingBuffer() *mpscRingBuffer {
+	r := &mpscRingBuffer{}
+	for i := uint64(0); i < ringSize; i++ {
+		r.slots[i].seq.Store(i)
+	}
+	return r
+}
+
+// Push enqueues e. It claims a slot via atomic fetch-and-add on tail, then
+// spins (yielding with runtime.Gosched) until the slot's seq matches the
+// claimed position — this spin is bounded by the consumer's Pop rate and is
+// extremely rare in practice (only when the ring is full).
+//
+// Safe for concurrent use by multiple producers.
+func (r *mpscRingBuffer) Push(e LogEvent) {
+	pos := r.tail.Add(1) - 1
+	slot := &r.slots[pos&ringMask]
+	for slot.seq.Load() != pos {
+		runtime.Gosched()
+	}
+	slot.data = e
+	slot.seq.Store(pos + 1)
+}
+
+// Pop dequeues the next event. Returns (event, true) if an event is available,
+// (LogEvent{}, false) if the ring is empty.
+//
+// Must be called from a single goroutine only (single-consumer invariant).
+func (r *mpscRingBuffer) Pop() (LogEvent, bool) {
+	pos := r.head.Load()
+	slot := &r.slots[pos&ringMask]
+	if slot.seq.Load() != pos+1 {
+		return LogEvent{}, false
+	}
+	e := slot.data
+	slot.seq.Store(pos + ringSize)
+	r.head.Store(pos + 1)
+	return e, true
+}
+
+// Len returns the approximate number of unread items in the ring.
+// The value is not precise under concurrent producers but is safe to read
+// from any goroutine (used for drain checks on the stop path).
+func (r *mpscRingBuffer) Len() int {
+	tail := r.tail.Load()
+	head := r.head.Load()
+	if tail <= head {
+		return 0
+	}
+	n := tail - head
+	if n > ringSize {
+		return ringSize
+	}
+	return int(n)
+}
+
+// atomicLoadUint64 is a helper for reading atomic.Uint64 fields via the
+// standard sync/atomic package — used only in the padding-size check below.
+var _ = atomic.LoadUint64 // ensure sync/atomic is imported

--- a/config/ring_buffer_bench_test.go
+++ b/config/ring_buffer_bench_test.go
@@ -1,0 +1,42 @@
+//go:build testing
+
+package config
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/architagr/lognugget/enum"
+)
+
+// BenchmarkRingBuffer_Push measures producer-side push throughput under
+// GOMAXPROCS=8 contention. Target: ≤ 100 ns/op per the P9 acceptance criteria.
+func BenchmarkRingBuffer_Push(b *testing.B) {
+	prev := runtime.GOMAXPROCS(8)
+	b.Cleanup(func() { runtime.GOMAXPROCS(prev) })
+
+	r := newMpscRingBuffer()
+
+	// Consumer goroutine drains continuously to prevent the ring from filling.
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				r.Pop()
+			}
+		}
+	}()
+	b.Cleanup(func() { close(stop) })
+
+	e := LogEvent{Level: enum.LevelInfo, Data: []byte(`{"level":"INFO"}`)}
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r.Push(e)
+		}
+	})
+}

--- a/config/ring_buffer_test.go
+++ b/config/ring_buffer_test.go
@@ -1,0 +1,183 @@
+//go:build testing
+
+package config
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/enum"
+)
+
+// Test_RingBuffer_PushPop_Sequential verifies FIFO ordering: push N events,
+// pop N events, values arrive in the same order.
+func Test_RingBuffer_PushPop_Sequential(t *testing.T) {
+	r := newMpscRingBuffer()
+	const n = 64
+
+	for i := 0; i < n; i++ {
+		r.Push(LogEvent{Level: enum.LogLevel(i), Data: nil})
+	}
+	for i := 0; i < n; i++ {
+		e, ok := r.Pop()
+		if !ok {
+			t.Fatalf("expected event at i=%d, got empty", i)
+		}
+		if int(e.Level) != i {
+			t.Errorf("FIFO violation at i=%d: got Level=%d", i, e.Level)
+		}
+	}
+	_, ok := r.Pop()
+	if ok {
+		t.Error("expected empty ring after draining all events")
+	}
+}
+
+// Test_RingBuffer_Empty verifies Pop on an empty ring returns (zero, false).
+func Test_RingBuffer_Empty(t *testing.T) {
+	r := newMpscRingBuffer()
+	e, ok := r.Pop()
+	if ok {
+		t.Errorf("expected (_, false) on empty ring, got (%v, true)", e)
+	}
+	if e.Level != 0 || e.Data != nil {
+		t.Errorf("expected zero LogEvent on empty pop, got %v", e)
+	}
+}
+
+// Test_RingBuffer_Full_Spins fills the ring to capacity and verifies that a
+// subsequent Push completes after a Pop frees one slot.
+func Test_RingBuffer_Full_Spins(t *testing.T) {
+	r := newMpscRingBuffer()
+
+	// Fill ring completely.
+	for i := 0; i < ringSize; i++ {
+		r.Push(LogEvent{Level: enum.LogLevel(i), Data: nil})
+	}
+
+	pushed := make(chan struct{})
+	go func() {
+		r.Push(LogEvent{Level: enum.LevelInfo, Data: nil})
+		close(pushed)
+	}()
+
+	// Brief pause to give the goroutine time to spin on a full ring.
+	time.Sleep(5 * time.Millisecond)
+
+	select {
+	case <-pushed:
+		t.Error("Push should not complete on a full ring before Pop frees a slot")
+	default:
+	}
+
+	// Free one slot — Push should now succeed.
+	r.Pop()
+
+	select {
+	case <-pushed:
+		// correct
+	case <-time.After(500 * time.Millisecond):
+		t.Error("Push did not complete within 500ms after Pop freed a slot")
+	}
+}
+
+// Test_RingBuffer_MPSC_Race runs 8 producer goroutines each pushing 1000
+// events and 1 consumer goroutine popping all events. Verifies no data race
+// (must be run with go test -race) and all events are received.
+func Test_RingBuffer_MPSC_Race(t *testing.T) {
+	const (
+		producers  = 8
+		perProducer = 1000
+		total       = producers * perProducer
+	)
+
+	r := newMpscRingBuffer()
+	var received atomic.Int64
+	done := make(chan struct{})
+
+	// Consumer.
+	go func() {
+		for {
+			_, ok := r.Pop()
+			if ok {
+				if received.Add(1) == total {
+					close(done)
+					return
+				}
+			}
+		}
+	}()
+
+	// Producers.
+	var wg sync.WaitGroup
+	for p := 0; p < producers; p++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perProducer; i++ {
+				r.Push(LogEvent{Level: enum.LevelInfo, Data: []byte{byte(id)}})
+			}
+		}(p)
+	}
+	wg.Wait()
+
+	select {
+	case <-done:
+		// All events received.
+	case <-time.After(5 * time.Second):
+		t.Errorf("timed out: only %d/%d events received", received.Load(), total)
+	}
+}
+
+// Test_RingBuffer_DrainOnStop pushes 100 events then triggers a config reset,
+// which closes ringDoneCh and causes ProcessLogEvent to drain the ring before
+// returning. Verifies all 100 events are dispatched — whether by normal pop
+// or by the drain-on-stop path.
+func Test_RingBuffer_DrainOnStop(t *testing.T) {
+	TestResetConfig()
+
+	var count atomic.Int64
+	InitPreProcessors(&testCounterProc{n: &count})
+
+	const n = 100
+	payload := []byte(`{"level":"INFO"}`)
+	for i := 0; i < n; i++ {
+		PublishLog(enum.LevelInfo, payload)
+	}
+
+	// TestResetConfig closes the current ringDoneCh, triggering the drain path
+	// in ProcessLogEvent, then starts a fresh ring+goroutine.
+	TestResetConfig()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if count.Load() >= n {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if got := count.Load(); got < n {
+		t.Errorf("drain-on-stop: %d/%d events dispatched", got, n)
+	}
+}
+
+type testCounterProc struct{ n *atomic.Int64 }
+
+func (c *testCounterProc) Name() string                           { return "counter" }
+func (c *testCounterProc) PreProcess(_ enum.LogLevel, _ []byte)  { c.n.Add(1) }
+
+// Test_RingBuffer_Len verifies Len() returns 0 on empty and ringSize on full.
+func Test_RingBuffer_Len(t *testing.T) {
+	r := newMpscRingBuffer()
+	if r.Len() != 0 {
+		t.Errorf("Len on empty ring = %d, want 0", r.Len())
+	}
+	for i := 0; i < ringSize; i++ {
+		r.Push(LogEvent{Level: enum.LevelInfo})
+	}
+	if r.Len() != ringSize {
+		t.Errorf("Len on full ring = %d, want %d", r.Len(), ringSize)
+	}
+}

--- a/config/string_escape_bench_test.go
+++ b/config/string_escape_bench_test.go
@@ -1,0 +1,25 @@
+// Package config_test provides the V3-P5 benchmark for AppendQuotedString.
+// No build tag — bench-check.sh runs without -tags and must always pick this up.
+package config_test
+
+import (
+	"testing"
+
+	"github.com/architagr/lognugget/config"
+)
+
+// BenchmarkAppendQuotedString_ASCII measures AppendQuotedString on a plain
+// ASCII input with a pre-allocated destination buffer. This simulates the hot
+// log path where a caller reuses a buffer across events.
+//
+// Input shape: 19-byte ASCII string, 64-byte pre-allocated dst.
+// Budget: 0 allocs/op after V3-P5 eliminates the []byte(s) conversion;
+// p99 must stay < 1 µs (project SLO).
+func BenchmarkAppendQuotedString_ASCII(b *testing.B) {
+	dst := make([]byte, 0, 64)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		dst = config.AppendQuotedString(dst[:0], "hello world message")
+	}
+}

--- a/config/string_escape_test.go
+++ b/config/string_escape_test.go
@@ -1,0 +1,66 @@
+//go:build testing
+
+// Package config: unit tests for the string-native appendJSONStringStr helper
+// (V3-P5). These tests are in package config (white-box) because they access
+// the unexported appendJSONStringStr and appendJSONString functions directly to
+// assert identical output without duplicating the escape logic.
+package config
+
+import (
+	"testing"
+)
+
+// Test_AppendJSONStringStr_MatchesByteVariant verifies that appendJSONStringStr
+// produces identical output to appendJSONString for every input category:
+// empty, plain ASCII, quote/backslash, tab/newline, multi-byte Unicode, low
+// control characters, and invalid UTF-8 bytes. This is the primary correctness
+// contract — the string variant must be a zero-allocation equivalent of the
+// []byte variant.
+func Test_AppendJSONStringStr_MatchesByteVariant(t *testing.T) {
+	inputs := []string{
+		"",
+		"hello",
+		"with \"quotes\"",
+		"with\\backslash",
+		"tab\there",
+		"newline\nhere",
+		"unicode: é中文",
+		"control\x01\x02\x1f",
+		string([]byte{0xff, 0xfe}), // invalid UTF-8
+	}
+	for _, s := range inputs {
+		got := appendJSONStringStr(nil, s)
+		want := appendJSONString(nil, []byte(s))
+		if string(got) != string(want) {
+			t.Errorf("input %q: got %q, want %q", s, got, want)
+		}
+	}
+}
+
+// Test_AppendJSONStringStr_EmptyString verifies that the empty string produces
+// exactly two double-quote characters — the minimal valid JSON string.
+func Test_AppendJSONStringStr_EmptyString(t *testing.T) {
+	got := appendJSONStringStr(nil, "")
+	if string(got) != `""` {
+		t.Errorf("got %q, want %q", got, `""`)
+	}
+}
+
+// Test_AppendJSONStringStr_ControlChars verifies RFC 8259 single-character
+// escape sequences: \t, \n, \r, \", and \\. These are the most frequently
+// occurring escapes in log strings and must be produced exactly.
+func Test_AppendJSONStringStr_ControlChars(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"\t", `"\t"`},
+		{"\n", `"\n"`},
+		{"\r", `"\r"`},
+		{"\"", `"\""`},
+		{"\\", `"\\"`},
+	}
+	for _, c := range cases {
+		got := string(appendJSONStringStr(nil, c.in))
+		if got != c.want {
+			t.Errorf("input %q: got %s, want %s", c.in, got, c.want)
+		}
+	}
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # LogNugget — Live Status Dashboard
 
-> **Last updated:** 2026-05-22 (Epic V3 stories created)
+> **Last updated:** 2026-05-22 (Epic V3 feature branch cut, all docs created)
 > **v1.0.0:** Released ✅ — [tag v1.0.0](https://github.com/architagr/LogNugget/releases/tag/v1.0.0) · [PR #80](https://github.com/architagr/LogNugget/pull/80) (merged)
 > **Umbrella:** [#12](https://github.com/architagr/LogNugget/issues/12)
 
@@ -287,7 +287,7 @@ SLO miss (hot-path 2× over 1 µs) does NOT block v1.0.0 per project decision �
 ## Epic V3 — Sub-500 ns hot path + first-class OTel distributed tracing
 
 > **Umbrella:** [#111](https://github.com/architagr/LogNugget/issues/111)
-> **Status:** 🚧 IN PROGRESS — stories created, implementation not started
+> **Status:** 🚧 IN PROGRESS — feature branch `feat/111-v3-performance` cut, all docs/stories created, implementation starting
 
 ### The gap (post-V2 baseline)
 
@@ -314,15 +314,15 @@ SLO miss (hot-path 2× over 1 µs) does NOT block v1.0.0 per project decision �
 
 | # | Issue | Story | Status |
 |---|-------|-------|--------|
-| P1 | [#112](https://github.com/architagr/LogNugget/issues/112) | atomic.Bool pre-processor gate | 🔲 TODO |
-| P2 | [#113](https://github.com/architagr/LogNugget/issues/113) | atomic.Pointer[HotSnapshot] copy-on-write snapshot | 🔲 TODO |
-| P3 | [#114](https://github.com/architagr/LogNugget/issues/114) | atomic channel pointer in PublishLog | 🔲 TODO |
-| P4 | [#115](https://github.com/architagr/LogNugget/issues/115) | AppendFormat direct timestamp (no string roundtrip) | 🔲 TODO |
-| P5 | [#116](https://github.com/architagr/LogNugget/issues/116) | appendJSONStringStr — string-native JSON escape | 🔲 TODO |
-| P6 | [#117](https://github.com/architagr/LogNugget/issues/117) | pre-rendered quoted level bytes | 🔲 TODO |
-| P7 | [#118](https://github.com/architagr/LogNugget/issues/118) | First-class OTel ContextFieldsAppender + tracing benchmark | 🔲 TODO |
-| P8 | [#119](https://github.com/architagr/LogNugget/issues/119) | exact-size buffer copy alias severance | 🔲 TODO |
-| P9 | [#120](https://github.com/architagr/LogNugget/issues/120) | lock-free MPSC ring buffer dispatch queue | 🔲 TODO |
+| P1 | [#112](https://github.com/architagr/LogNugget/issues/112) | atomic.Bool pre-processor gate | 🔲 TODO — story ready, branch `feat/112-p1-atomic-preprocessor-gate` |
+| P2 | [#113](https://github.com/architagr/LogNugget/issues/113) | atomic.Pointer[HotSnapshot] copy-on-write snapshot | 🔲 TODO — story ready, branch `feat/113-p2-atomic-pointer-snapshot` |
+| P3 | [#114](https://github.com/architagr/LogNugget/issues/114) | atomic channel pointer in PublishLog | 🔲 TODO — story ready, branch `feat/114-p3-atomic-channel-pointer` |
+| P4 | [#115](https://github.com/architagr/LogNugget/issues/115) | AppendFormat direct timestamp (no string roundtrip) | 🔲 TODO — story ready, branch `feat/115-p4-direct-timestamp` |
+| P5 | [#116](https://github.com/architagr/LogNugget/issues/116) | appendJSONStringStr — string-native JSON escape | 🔲 TODO — story ready, branch `feat/116-p5-string-native-escape` |
+| P6 | [#117](https://github.com/architagr/LogNugget/issues/117) | pre-rendered quoted level bytes | 🔲 TODO — story ready, branch `feat/117-p6-prerendered-level-bytes` |
+| P7 | [#118](https://github.com/architagr/LogNugget/issues/118) | First-class OTel ContextFieldsAppender + tracing benchmark | 🔲 TODO — story ready, branch `feat/118-p7-otel-context-appender` |
+| P8 | [#119](https://github.com/architagr/LogNugget/issues/119) | exact-size buffer copy alias severance | 🔲 TODO — story ready, branch `feat/119-p8-exact-buffer-size` |
+| P9 | [#120](https://github.com/architagr/LogNugget/issues/120) | lock-free MPSC ring buffer dispatch queue | 🔲 TODO — story ready, branch `feat/120-p9-mpsc-ring-buffer` |
 
 ---
 

--- a/docs/epics/lognugget/epic-V3-performance.md
+++ b/docs/epics/lognugget/epic-V3-performance.md
@@ -1,0 +1,72 @@
+# Epic V3 — Sub-500 ns Hot Path + First-Class OTel Distributed Tracing
+
+Milestone: V3 (2026-05-22 → gate-green on feat/111-v3-performance).
+Owner: Project Lead.
+Umbrella issue: [#111](https://github.com/architagr/LogNugget/issues/111).
+Goal: cut the parallel hot path from ~1,090 ns/op / 5 allocs to ≤ 500 ns/op / ≤ 1 alloc by eliminating every remaining RLock on the hot path, shrinking per-call allocations to zero, and adding first-class OTel distributed tracing support.
+
+## In scope
+
+| Group | Issue | Bottleneck | Est. saving |
+|---|---|---|---|
+| P1 — atomic.Bool pre-processor gate | #112 | `HasEventPreProcessors()` acquires `configMu.RLock` every call | ~80 ns |
+| P2 — atomic.Pointer[HotSnapshot] copy-on-write | #113 | `GetHotSnapshot()` acquires `configMu.RLock` + copies 13-field struct | ~120 ns |
+| P3 — atomic channel pointer in PublishLog | #114 | `PublishLog()` acquires `configMu.RLock` for channel pointer | ~50 ns |
+| P4 — AppendFormat direct timestamp | #115 | `customTime.Format()` returns string; `AppendQuotedString` converts back to `[]byte` | ~40 ns, 2 allocs |
+| P5 — appendJSONStringStr string-native escape | #116 | `AppendQuotedString` calls `[]byte(s)` on every string field | ~20 ns, 2 allocs |
+| P6 — pre-rendered quoted level bytes | #117 | `level.String()` + `AppendQuotedString` — 5 known-constant values | ~15 ns, 1 alloc |
+| P7 — first-class OTel ContextFieldsAppender | #118 | No built-in OTel; benchmark uses legacy map parser (~100 ns, 4 allocs) | ~100 ns, 4 allocs |
+| P8 — exact-size buffer alias severance | #119 | New pool buf always 1024 B regardless of actual log line size (~200 B) | ~800 B/call |
+| P9 — lock-free MPSC ring buffer | #120 | Go channel contention under 8-goroutine load costs ~130 ns | ~130 ns |
+
+## Out of scope
+
+- New encoder formats (CBOR, Protobuf, plain-text variants).
+- Changes to the `LogEntry` public API (method signatures, level methods).
+- New log levels or changes to `enum.LogLevel` taxonomy.
+- Changes to `Fatal`/`Panic` semantics.
+- Raising or bypassing the bench-check gate threshold.
+- Bundling OTel SDK as a core dependency (OTel integration lives in `examples/otel-appender/`).
+
+## Exit criteria
+
+1. `./scripts/bench-check.sh` green on `feat/111-v3-performance`.
+2. `Benchmark_Log_Parallel_NoCtx` (GOMAXPROCS=8): ≤ 500 ns/op.
+3. `Benchmark_Log_Parallel_10CtxFields` with `SetContextFieldsAppender`: ≤ 500 ns/op, ≤ 1 alloc/op.
+4. Filtered path (`BenchmarkLogEntry_FilteredPath`): 0 allocs, ≤ 35 ns/op — must not regress from V2.
+5. `go test ./...` green, `go test -race ./...` green.
+6. `golangci-lint run` clean.
+7. Project Lead runs `./scripts/bench-check.sh --update-baseline`; baseline commit references #111.
+
+## Stories
+
+| Story | Issue | Branch |
+|---|---|---|
+| P1 — atomic.Bool pre-processor gate | #112 | `feat/112-p1-atomic-preprocessor-gate` |
+| P2 — atomic.Pointer[HotSnapshot] | #113 | `feat/113-p2-atomic-pointer-snapshot` |
+| P3 — atomic channel pointer | #114 | `feat/114-p3-atomic-channel-pointer` |
+| P4 — direct timestamp append | #115 | `feat/115-p4-direct-timestamp` |
+| P5 — string-native JSON escape | #116 | `feat/116-p5-string-native-escape` |
+| P6 — pre-rendered level bytes | #117 | `feat/117-p6-prerendered-level-bytes` |
+| P7 — OTel ContextFieldsAppender | #118 | `feat/118-p7-otel-context-appender` |
+| P8 — exact-size buffer severance | #119 | `feat/119-p8-exact-buffer-size` |
+| P9 — lock-free MPSC ring buffer | #120 | `feat/120-p9-mpsc-ring-buffer` |
+
+Note: Sub-branches use `feat/<issue>-<slug>` naming (not nested `/`). All story PRs target `feat/111-v3-performance`.
+
+## Dependency order
+
+```
+feat/111-v3-performance
+├── P1 (#112) — independent; unblocks nothing but removes a lock on EVERY hot call
+├── P6 (#117) — independent; pure hot-path win
+├── P5 (#116) — independent; hot-path win
+├── P4 (#115) — independent; hot-path win
+├── P8 (#119) — independent; small, safe
+├── P2 (#113) — after P1 merged (touches same configMu region); biggest single win
+├── P3 (#114) — after P2 merged (same PublishLog region)
+├── P7 (#118) — after P2 merged (benchmark update uses zero-alloc appender path)
+└── P9 (#120) — last; replaces channel entirely; validates on full P1-P8 stack
+```
+
+P1, P4, P5, P6, P8 may be worked in parallel. P2 should start after P1 merges to the feature branch to avoid a large conflict in `config.go`. P3 and P7 start after P2. P9 is last.

--- a/docs/prds/v3-performance.md
+++ b/docs/prds/v3-performance.md
@@ -1,0 +1,297 @@
+# PRD: Epic V3 — Sub-500 ns Hot Path + First-Class OTel Distributed Tracing
+
+| Field | Value |
+|---|---|
+| Feature slug | `v3-performance` |
+| Umbrella issue | [#111](https://github.com/architagr/LogNugget/issues/111) |
+| Status | READY FOR IMPLEMENTATION |
+| Author | Delivery Manager |
+| Date | 2026-05-22 |
+| Target branch | `feat/111-v3-performance` → `develop` |
+
+---
+
+## 1. Summary
+
+LogNugget V2 ships at ~1,090 ns/op and 5 allocs/op on the parallel no-context hot path — a 10× improvement over V1 — but still 10× slower than zerolog on raw ns/op. The project SLO targets < 1 µs p99; V3 targets ≤ 500 ns/op (≤ 1 alloc) on the parallel path, closing half the remaining gap.
+
+V3 eliminates every remaining `configMu.RLock` from the hot path (three separate sites: pre-processor check, config snapshot, channel publish), removes all per-call string→[]byte conversions (timestamp, string fields, level label), adds first-class OpenTelemetry context tracing support via the existing `ContextFieldsAppender` API, right-sizes the per-call buffer allocation, and replaces the Go channel dispatcher with a lock-free MPSC ring buffer.
+
+All changes target caller-side cost (the ~1,090 ns callers pay before returning). IO flush remains async.
+
+---
+
+## 2. Scope
+
+### In scope
+
+| Story | Issue | Bottleneck | Est. saving |
+|---|---|---|---|
+| P1 — atomic.Bool pre-processor gate | #112 | `HasEventPreProcessors()` RLock every call | ~80 ns |
+| P2 — atomic.Pointer[HotSnapshot] | #113 | `GetHotSnapshot()` RLock + 13-field struct copy | ~120 ns |
+| P3 — atomic channel pointer | #114 | `PublishLog()` RLock for channel pointer | ~50 ns |
+| P4 — direct timestamp append | #115 | `Format()` string + `[]byte(s)` roundtrip | ~40 ns, 2 allocs |
+| P5 — string-native JSON escape | #116 | `AppendQuotedString` `[]byte(s)` per string field | ~20 ns, 2 allocs |
+| P6 — pre-rendered level bytes | #117 | `level.String()` + `AppendQuotedString` | ~15 ns, 1 alloc |
+| P7 — first-class OTel appender | #118 | Benchmark uses legacy map parser (+100 ns, +4 allocs) | ~100 ns, 4 allocs |
+| P8 — exact-size buffer severance | #119 | Pool buf always 1024 B vs ~200 B actual | ~800 B/call |
+| P9 — lock-free MPSC ring buffer | #120 | Channel contention under 8 goroutines ~130 ns | ~130 ns |
+
+### Out of scope
+
+- New encoder formats.
+- OTel SDK as a module dependency in the core library.
+- Changes to `LogEntry` public API signatures.
+- New log levels.
+- Raising the bench-check gate threshold.
+
+---
+
+## 3. Open Questions — Resolved
+
+### Q1 — P2 atomic snapshot consistency during Set* mutations
+
+**Decision:** All `Set*` mutators acquire `configMu.Lock()` as before, build the full `HotSnapshot` under the lock, then call `hotSnapshotPtr.Store(&snap)` before releasing the lock. Readers call `hotSnapshotPtr.Load()` without any lock. This is a classic copy-on-write pattern; readers always see a fully-consistent snapshot (no torn reads) because they read a single pointer that points to an immutable struct.
+
+Rationale: `atomic.Pointer[HotSnapshot]` provides the same memory-ordering guarantee as a mutex for the read side, with zero lock contention. Writers still use the existing `configMu.Lock()` to serialise concurrent `Set*` calls — no change to write semantics.
+
+### Q2 — P3 atomic channel: what happens during resetConfig?
+
+**Decision:** `resetConfig` creates `newCh`, acquires `configMu.Lock()`, sets the package-level `ch = newCh`, calls `atomicCh.Store(newCh)` to update the atomic copy, then releases the lock. `PublishLog` loads `atomicCh` (no lock). Because `atomicCh.Store` happens under the write lock and `atomicCh.Load` in `PublishLog` uses `atomic.Value` semantics, any `PublishLog` call that begins after `resetConfig` returns will see the new channel. Calls in-flight during `resetConfig` may still use the old channel — the existing behaviour is preserved.
+
+### Q3 — P4 timestamp escaping
+
+**Decision:** RFC3339 timestamps contain only printable ASCII characters (digits, `T`, `Z`, `-`, `:`, `+`, `.`). None require JSON escaping. `entry.logWithSkip` will write the timestamp as `'"'` + `t.AppendFormat(dst, layout)` + `'"'` directly, bypassing `AppendQuotedString`. A comment documents the invariant. If `snap.TimeFormat` is ever set to a layout that could produce quote or backslash characters (not possible with any stdlib layout), the fast path still produces valid JSON because those characters do not appear in the output.
+
+### Q4 — P5 backward compatibility: `appendJSONString` still needed?
+
+**Decision:** Keep `appendJSONString(dst []byte, src []byte)` for the `AppendField` `error` and `time.Time` cases that produce `[]byte` via `.Error()` and `.Format()`. Add new `appendJSONStringStr(dst []byte, s string)` that iterates over the string directly. `AppendQuotedString(dst []byte, s string)` becomes a thin wrapper over `appendJSONStringStr`. All string-value hot paths (`KindStr` in `AppendAttr`, string case in `AppendField`) switch to `appendJSONStringStr`. Zero API change.
+
+### Q5 — P9 ring buffer size and overflow
+
+**Decision:** Ring buffer capacity = 4096 slots (4× channel default of 1000). If all slots fill (burst exceeding drain throughput), producers spin calling `runtime.Gosched()` until a slot is available — same back-pressure semantics as the existing channel. No events are dropped. The ring buffer is initialised in `resetConfig`; `ProcessLogEvent` is updated to drain it via a spinning loop with `runtime.Gosched()` fallback on empty. The `SetChannelCapacity` function remains for backward compat but does not affect ring buffer size post-P9 (documented).
+
+---
+
+## 4. Functional Requirements
+
+### MUST — blocking for Epic V3
+
+| ID | Requirement | Story |
+|---|---|---|
+| F1 | `HasEventPreProcessors()` uses an `atomic.Bool` load; acquires no mutex. | P1 / #112 |
+| F2 | `InitPreProcessors`, `AddPreProcessors`, `RemovePreProcessor` update the `atomic.Bool` under `configMu.Lock()` so reads are always consistent. | P1 / #112 |
+| F3 | `GetHotSnapshot()` returns `*hotSnapshotPtr.Load()` without acquiring `configMu`. | P2 / #113 |
+| F4 | Every `Set*` mutator rebuilds and atomically stores a new `HotSnapshot` after writing to `defaultConfig`, still under `configMu.Lock()`. | P2 / #113 |
+| F5 | `PublishLog` reads the dispatch channel via `atomicCh.Load()` without acquiring `configMu`. | P3 / #114 |
+| F6 | `resetConfig` stores the new channel into `atomicCh` under `configMu.Lock()`. | P3 / #114 |
+| F7 | Timestamp is appended as `'"' + t.AppendFormat(buf, layout) + '"'` in `logWithSkip`; `customTime.Format` (string-returning) is no longer called on the hot path. | P4 / #115 |
+| F8 | `appendJSONStringStr(dst []byte, s string)` is added to `config/parse_field.go`; it iterates over the string without a `[]byte(s)` conversion. | P5 / #116 |
+| F9 | `AppendQuotedString`, `AppendAttr` (KindStr), and `AppendField` (string case) all use `appendJSONStringStr`. | P5 / #116 |
+| F10 | `config.AppendQuotedLevel(dst []byte, l enum.LogLevel) []byte` is added; it uses a switch over the 5 named levels to append pre-quoted bytes (e.g. `"INFO"`) without calling `level.String()`. | P6 / #117 |
+| F11 | `logWithSkip` calls `config.AppendQuotedLevel(e.buf, level)` instead of `config.AppendQuotedString(e.buf, level.String())`. | P6 / #117 |
+| F12 | `Benchmark_Log_Parallel_10CtxFields` in `entry/parallel_bench_test.go` and `test/benchmark/log_parallel_bench_test.go` use `config.SetContextFieldsAppender` instead of `config.SetContextFieldsParser`. | P7 / #118 |
+| F13 | A new `Benchmark_Log_Parallel_OtelCtx` benchmark in `test/benchmark/` demonstrates OTel span extraction via `ContextFieldsAppender`; OTel SDK is imported only in that test file's `go.mod`-isolated benchmark module or via a build tag. | P7 / #118 |
+| F14 | `examples/otel-appender/` contains a runnable example showing how to create a `ContextFieldsAppender` that reads OTel trace/span IDs from `context.Context`. | P7 / #118 |
+| F15 | Alias severance in `logWithSkip` uses `len(data)` as the new backing capacity: `e.buf = make([]byte, 0, len(data))`. | P8 / #119 |
+| F16 | `config.mpscRingBuffer` replaces `chan LogEvent` as the dispatch mechanism; `PublishLog` calls `ring.Push(LogEvent{...})`; `ProcessLogEvent` loops on `ring.Pop()` with `runtime.Gosched()` on empty. | P9 / #120 |
+| F17 | All nine stories ship with a `*_bench_test.go` covering the changed hot path with `b.ReportAllocs()`. | All |
+| F18 | `./scripts/bench-check.sh` exits 0 after all stories merged. | All |
+
+### SHOULD
+
+| ID | Requirement | Story |
+|---|---|---|
+| F19 | `AppendQuotedLevel` is exported and documented in godoc with the note that it is faster than `AppendQuotedString(dst, l.String())`. | P6 / #117 |
+| F20 | `examples/otel-appender/README.md` explains the zero-alloc OTel integration pattern. | P7 / #118 |
+| F21 | `SetChannelCapacity` godoc updated to note it does not affect ring buffer size post-P9. | P9 / #120 |
+
+### COULD
+
+| ID | Requirement | Notes |
+|---|---|---|
+| F22 | `config.AppendQuotedBool(dst []byte, v bool) []byte` pre-renders `"true"` / `"false"` literals. | Micro-win; add only if budget allows. |
+| F23 | Ring buffer capacity configurable via `config.SetRingBufferSize(n int)`. | Nice to have; default 4096 covers all realistic loads. |
+
+---
+
+## 5. Non-Functional Requirements
+
+### 5.1 Latency (hard gate)
+
+| Path | Metric | V3 Target | V2 Baseline |
+|---|---|---|---|
+| Parallel NoCtx (GOMAXPROCS=8) | mean ns/op | ≤ 500 | ~1,090 |
+| Parallel 10 ctx fields (appender) | mean ns/op | ≤ 500 | ~1,280 |
+| Filtered path | mean ns/op | ≤ 35 | ~10 (must not regress) |
+| Filtered path | allocs/op | 0 | 0 (must not regress) |
+
+### 5.2 Allocations
+
+| Path | V3 Target | V2 Baseline |
+|---|---|---|
+| Parallel NoCtx | ≤ 1 alloc/op | 5 |
+| Parallel 10 ctx fields (appender) | ≤ 1 alloc/op | 7 |
+| Filtered path | 0 | 0 |
+
+### 5.3 Bytes/op
+
+| Path | V3 Target | V2 Baseline |
+|---|---|---|
+| Parallel hot path | ≤ 300 B/op | ~1,411 B/op |
+
+### 5.4 Race Safety
+
+All changes must pass `go test -race ./...` with no new data races. `atomic.Bool`, `atomic.Pointer[HotSnapshot]`, and `atomic.Value` (channel) provide the same memory-ordering guarantees as `sync.RWMutex` for their respective read paths.
+
+### 5.5 Backward Compatibility
+
+No breaking change to any exported symbol. `HasEventPreProcessors`, `GetHotSnapshot`, `PublishLog` retain their signatures. `SetChannelCapacity` remains callable (post-P9 its effect is documented as applying only before P9 ring buffer init). `ContextFieldsParser` legacy path remains supported (P7 switches benchmarks to the appender but does not remove the parser).
+
+### 5.6 Compliance
+
+- No new module-level dependencies in the core library.
+- `go mod tidy` produces no diff.
+- `golangci-lint run` green on every story PR.
+
+---
+
+## 6. Delivery Order
+
+```
+feat/111-v3-performance
+├── Batch 1 (parallel — touch disjoint code regions):
+│   ├── P1 (#112): config.go — atomic.Bool gate
+│   ├── P4 (#115): entry.go — timestamp append
+│   ├── P5 (#116): parse_field.go — string escape
+│   ├── P6 (#117): parse_field.go — level bytes
+│   └── P8 (#119): entry.go — buffer size
+├── Batch 2 (after Batch 1 merged):
+│   ├── P2 (#113): config.go — atomic snapshot (touches same file as P1)
+│   └── P7 (#118): benchmarks + examples
+├── Batch 3 (after P2 merged):
+│   └── P3 (#114): config.go — atomic channel
+└── Batch 4 (final):
+    └── P9 (#120): ring buffer (replaces channel)
+```
+
+### Milestone targets
+
+| Milestone | Gate |
+|---|---|
+| M1: Batch 1 merged | No regression on filtered path; allocs down by 3+ from V2 |
+| M2: Batch 2 merged | `GetHotSnapshot()` lock-free; benchmark 10ctx uses appender |
+| M3: P3 merged | Zero RLocks on hot path |
+| M4: P9 merged | `Benchmark_Log_Parallel_NoCtx` ≤ 500 ns/op |
+| M5: Baseline update | Project Lead runs `--update-baseline`; PR to `develop` opened |
+
+---
+
+## 7. Per-Story Acceptance Criteria
+
+### P1 — atomic.Bool pre-processor gate (#112)
+
+| Criterion | Target |
+|---|---|
+| `HasEventPreProcessors()` acquires configMu | Never (atomic load only) |
+| `Test_HasPreProcessors_Race` under -race | Clean |
+| `BenchmarkHasPreProcessors` | ≤ 5 ns/op, 0 allocs |
+| All existing tests | Pass without modification |
+
+### P2 — atomic.Pointer[HotSnapshot] (#113)
+
+| Criterion | Target |
+|---|---|
+| `GetHotSnapshot()` acquires configMu | Never |
+| `Test_HotSnapshot_ConsistentWithSetMinLevel` | Pass |
+| `Test_HotSnapshot_RaceWithSetters` (8 goroutines, -race) | Clean |
+| `GetHotSnapshot()` benchmark | ≤ 20 ns/op, 0 allocs |
+| All Set* mutators rebuild snapshot | Verified by test |
+
+### P3 — atomic channel pointer (#114)
+
+| Criterion | Target |
+|---|---|
+| `PublishLog` acquires configMu | Never |
+| `Test_PublishLog_Race` (8 goroutines, -race) | Clean |
+| Channel send semantics unchanged | Yes |
+
+### P4 — direct timestamp (#115)
+
+| Criterion | Target |
+|---|---|
+| `customTime.Format` called on hot path | Never |
+| `BenchmarkTimestamp_Direct` | 0 allocs/op |
+| Timestamp field in log output | Correct RFC3339 format |
+
+### P5 — string-native escape (#116)
+
+| Criterion | Target |
+|---|---|
+| `[]byte(s)` in `AppendQuotedString` | Eliminated |
+| `BenchmarkAppendQuotedString` | 0 allocs/op for pure ASCII strings |
+| Existing escape tests | Pass |
+
+### P6 — pre-rendered level bytes (#117)
+
+| Criterion | Target |
+|---|---|
+| `level.String()` called on hot path | Never for named levels |
+| `BenchmarkAppendQuotedLevel` | 0 allocs/op |
+| All 5 named levels render correctly | Verified by table test |
+
+### P7 — OTel appender (#118)
+
+| Criterion | Target |
+|---|---|
+| `Benchmark_Log_Parallel_10CtxFields` uses appender | Yes |
+| `Benchmark_Log_Parallel_OtelCtx` exists | Yes |
+| `examples/otel-appender/` compiles | Yes |
+| Legacy `SetContextFieldsParser` tests | Pass unchanged |
+
+### P8 — exact buffer size (#119)
+
+| Criterion | Target |
+|---|---|
+| Pool buf size after severance | `len(data)` (not 1024) |
+| B/op on parallel bench | ≤ 300 B/op |
+| Filtered path allocs | 0 (no regression) |
+
+### P9 — lock-free MPSC ring buffer (#120)
+
+| Criterion | Target |
+|---|---|
+| `chan LogEvent` dispatch | Replaced by ring buffer |
+| Producer goroutines | 8 concurrent — no data race under -race |
+| `Benchmark_Log_Parallel_NoCtx` | ≤ 500 ns/op |
+| `Benchmark_Log_Parallel_10CtxFields` | ≤ 500 ns/op |
+| Stop/drain semantics | Preserved — all events drained before Stop returns |
+
+---
+
+## 8. Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| P2 snapshot stale reads: a `Set*` call races with a `GetHotSnapshot` | Low | Low | atomic.Pointer provides sequential consistency; readers always see the most recently stored snapshot or the one before it — both are valid complete states. |
+| P9 ring buffer: producer overtakes consumer (full ring) | Medium | Medium | Spinning with `runtime.Gosched()` provides back-pressure; same semantics as channel blocking. Ring size 4096 >> realistic burst. |
+| P9 memory ordering: slot written by producer before seq updated | N/A with atomic.Uint64 | High | The `slot.seq.Store(pos+1)` with atomic store provides the release barrier; consumer's `slot.seq.Load()` provides the acquire barrier. Use `atomic.Uint64` throughout. |
+| P8 smaller buf causes realloc on large log lines | Low | Low | `len(data)` adapts to actual line size; pool reuses the slice whose capacity grows organically. First call on a large line causes one realloc; subsequent reuses of that slot are free. |
+| P5 `appendJSONStringStr` diverges from `appendJSONString` | Low | Medium | Both use the same `cfgEscapeTable`; the only difference is input type. Cross-test with identical inputs in `Test_AppendJSONStringStr_MatchesByteVariant`. |
+
+---
+
+## 9. Definition of Done (Epic)
+
+All of the following must be true before umbrella issue #111 is closed:
+
+1. `Benchmark_Log_Parallel_NoCtx` (GOMAXPROCS=8) ≤ 500 ns/op.
+2. `Benchmark_Log_Parallel_10CtxFields` (appender) ≤ 500 ns/op, ≤ 1 alloc/op.
+3. `BenchmarkLogEntry_FilteredPath` ≤ 35 ns/op, 0 allocs (no regression from V2).
+4. `go test -race ./...` exits 0.
+5. `golangci-lint run` exits 0.
+6. `./scripts/bench-check.sh` exits 0.
+7. All 9 story PRs merged into `feat/111-v3-performance`.
+8. `bench-baseline.txt` updated by Project Lead.
+9. `examples/otel-appender/` compiles and runs correctly.
+10. `docs/STATUS.md` updated with V3 results.

--- a/docs/stories/lognugget/STORY_INDEX.md
+++ b/docs/stories/lognugget/STORY_INDEX.md
@@ -54,6 +54,33 @@ PENDING / TESTS_DRAFTED / TESTS_APPROVED / IMPL_IN_PROGRESS / DRAFT_PR / READY /
 | 039 | #54 | Fix config.ResetConfig race | A | engineer | NF7, NF9, race | 200 | 006 | MERGED |
 | 040 | #55 | Story 001 doc drift fix | A | N/A (PL) | doc | ≤30 | — | DONE |
 
+## Epic V2 — Performance stories
+
+| # | Issue | Title | Epic | Owner-role | LOC | Deps | Status |
+|---|---|---|---|---|---|---|---|
+| V2-P1 | #82 | Atomic minLevel + single config snapshot | V2 | engineer | 180 | — | MERGED |
+| V2-P2 | #83 | Typed field API (Str/Int/Bool/Float64) | V2 | engineer | 200 | V2-P1 | MERGED |
+| V2-P3 | #84 | Append-to-buf context API | V2 | engineer | 180 | V2-P1 | MERGED |
+| V2-P4 | #85 | Inline framing — eliminate double-buffer | V2 | engineer | 160 | V2-P1 | MERGED |
+| V2-P5 | #86 | Channel capacity 1000 + configurable | V2 | engineer | 80 | — | MERGED |
+
+## Epic V3 — Sub-500 ns + OTel stories
+
+Feature branch: `feat/111-v3-performance` (off `develop`).
+Umbrella issue: **#111**.
+
+| # | Issue | Title | Epic | Owner-role | LOC | Deps | Status |
+|---|---|---|---|---|---|---|---|
+| V3-P1 | #112 | atomic.Bool pre-processor gate | V3 | engineer | 80 | — | TODO |
+| V3-P2 | #113 | atomic.Pointer[HotSnapshot] copy-on-write | V3 | engineer | 200 | V3-P1 | TODO |
+| V3-P3 | #114 | Atomic channel pointer in PublishLog | V3 | engineer | 50 | V3-P2 | TODO |
+| V3-P4 | #115 | AppendFormat direct timestamp | V3 | engineer | 40 | — | TODO |
+| V3-P5 | #116 | appendJSONStringStr string-native escape | V3 | engineer | 100 | — | TODO |
+| V3-P6 | #117 | Pre-rendered quoted level bytes | V3 | engineer | 60 | — | TODO |
+| V3-P7 | #118 | First-class OTel ContextFieldsAppender + bench | V3 | engineer | 150 | V3-P2 | TODO |
+| V3-P8 | #119 | Exact-size buffer alias severance | V3 | engineer | 30 | — | TODO |
+| V3-P9 | #120 | Lock-free MPSC ring buffer dispatch | V3 | engineer | 280 | V3-P1..P8 | TODO |
+
 ## SC traceability
 
 | SC | Stories that close it |

--- a/docs/stories/lognugget/V3/story-P1-atomic-preprocessor-gate.md
+++ b/docs/stories/lognugget/V3/story-P1-atomic-preprocessor-gate.md
@@ -1,0 +1,42 @@
+# P1 — atomic.Bool Pre-Processor Gate
+
+Owner-role: engineer.
+Issue: [#112](https://github.com/architagr/LogNugget/issues/112).
+Branch: `feat/112-p1-atomic-preprocessor-gate` (cut from `feat/111-v3-performance`, PRs back to `feat/111-v3-performance`).
+Depends: none. P1 is independent; start immediately.
+LOC est: 80.
+
+## Summary
+
+Replace `HasEventPreProcessors()` — which currently acquires `configMu.RLock()` on every hot-path call — with an `atomic.Bool` load. The three mutators (`InitPreProcessors`, `AddPreProcessors`, `RemovePreProcessor`) update the atomic under the existing `configMu.Lock()` so the invariant is always consistent.
+
+**Saving:** ~80 ns per log event (one RLock eliminated from the hot path before any allocation runs).
+
+## Files touched
+
+- `config/config.go` — add `hasPreProcessorsAtomic atomic.Bool` var; rewrite `HasEventPreProcessors()`; update `InitPreProcessors`, `AddPreProcessors`, `RemovePreProcessor`
+- NEW `config/atomic_preprocessor_bench_test.go` — `BenchmarkHasEventPreProcessors`, race test
+
+## Tests-first gate
+
+1. `Test_HasPreProcessors_TrueAfterInit` — after `InitPreProcessors(fakeProc)`, `HasEventPreProcessors()` returns `true`.
+2. `Test_HasPreProcessors_FalseAfterRemove` — after `InitPreProcessors(fakeProc)` then `RemovePreProcessor(name)`, returns `false`.
+3. `Test_HasPreProcessors_FalseOnEmpty` — after `InitPreProcessors()` with no args, returns `false`.
+4. `Test_HasPreProcessors_Race` — 4 goroutines calling `AddPreProcessors`/`RemovePreProcessor` concurrently with 4 goroutines calling `HasEventPreProcessors()`, under `-race`; no race detected.
+5. `BenchmarkHasEventPreProcessors` — ≤ 5 ns/op, 0 allocs/op (verify atomic load is fast).
+
+## Acceptance criteria
+
+1. `HasEventPreProcessors()` acquires `configMu` zero times — no `RLock` call present in the function body.
+2. `hasPreProcessorsAtomic` is updated in all three mutator paths: `InitPreProcessors`, `AddPreProcessors`, `RemovePreProcessor`.
+3. `Test_HasPreProcessors_Race` passes under `go test -race`.
+4. `BenchmarkHasEventPreProcessors`: ≤ 5 ns/op, 0 allocs/op.
+5. All existing `config/` and `entry/` tests pass without modification.
+
+## Assignment
+
+Assigned to: agent-engineer
+Branch: feat/112-p1-atomic-preprocessor-gate
+Target PR: feat/111-v3-performance
+Date: 2026-05-22
+PL instruction: Write tests FIRST. Present test suite before any implementation. Confirm 0 allocs/op on `BenchmarkHasEventPreProcessors` before marking PR ready.

--- a/docs/stories/lognugget/V3/story-P2-atomic-pointer-snapshot.md
+++ b/docs/stories/lognugget/V3/story-P2-atomic-pointer-snapshot.md
@@ -1,0 +1,74 @@
+# P2 — atomic.Pointer[HotSnapshot] Copy-on-Write Snapshot
+
+Owner-role: engineer.
+Issue: [#113](https://github.com/architagr/LogNugget/issues/113).
+Branch: `feat/113-p2-atomic-pointer-snapshot` (cut from `feat/111-v3-performance`, PRs back to `feat/111-v3-performance`).
+Depends: P1 merged to feat/111-v3-performance (touches same `config.go` region; start after P1 to avoid conflict).
+LOC est: 200.
+
+## Summary
+
+Replace `GetHotSnapshot()` — which acquires `configMu.RLock()` and copies a 13-field struct — with an atomic pointer load. A package-level `atomic.Pointer[HotSnapshot]` stores the current snapshot; all `Set*` mutators and `resetConfig` rebuild and atomically store a new snapshot under the existing `configMu.Lock()`. Readers call `hotSnapshotPtr.Load()` without any lock.
+
+**Saving:** ~120 ns per log event (the biggest single win in V3 — one RLock + struct copy eliminated).
+
+## Files touched
+
+- `config/config.go`:
+  - Add `var hotSnapshotPtr atomic.Pointer[HotSnapshot]`
+  - Add `func storeHotSnapshot()` (called under `configMu.Lock()` by all writers)
+  - Rewrite `GetHotSnapshot()` to `return *hotSnapshotPtr.Load()`
+  - Update `resetConfig` to call `storeHotSnapshot()` after writing `defaultConfig`
+  - Update all 10 `Set*` mutators to call `storeHotSnapshot()` after writing their field
+- NEW `config/atomic_snapshot_v3_bench_test.go` — `BenchmarkGetHotSnapshot`
+
+## storeHotSnapshot implementation
+
+```go
+// storeHotSnapshot builds a new HotSnapshot from current state and stores it
+// atomically. Must be called while holding configMu (write lock).
+func storeHotSnapshot() {
+    snap := &HotSnapshot{
+        AddSource:        defaultConfig.addSource,
+        TimeFormat:       defaultConfig.timeFormat,
+        DefaultFields:    defaultConfig.defaultFields,
+        Rendered:         defaultConfig.defaultFieldsRendered,
+        StaticFields:     defaultConfig.parsedStaticFields,
+        ContextParser:    defaultConfig.contextParser,
+        ContextAppender:  defaultConfig.contextAppender,
+        Encoder:          defaultConfig.encoderObj,
+        EncoderType:      defaultConfig.encoderType,
+        RestrictedFields: restrictedFieldsSet,
+    }
+    snap.EncoderOpen  = snap.Encoder.OpenBytes()
+    snap.EncoderClose = snap.Encoder.CloseBytes()
+    hotSnapshotPtr.Store(snap)
+}
+```
+
+Note: `storeHotSnapshot` must be called **after** any field is written to `defaultConfig` and **while still holding `configMu.Lock()`**. This ensures the stored pointer always points to a fully consistent snapshot.
+
+## Tests-first gate
+
+1. `Test_GetHotSnapshot_NilSafe` — after `resetConfig`, `hotSnapshotPtr.Load()` is not nil.
+2. `Test_HotSnapshot_ConsistentWithSetMinLevel` — after `SetMinLevel(LevelWarn)`, `GetHotSnapshot().TimeFormat` equals `GetConfig().TimeFormat` AND `GetAtomicMinLevel()` returns `LevelWarn` — snapshot and atomic are both updated.
+3. `Test_HotSnapshot_ConsistentWithSetTimeFormat` — after `SetTimeFormat("2006-01-02")`, `GetHotSnapshot().TimeFormat` equals `"2006-01-02"`.
+4. `Test_HotSnapshot_RaceWithSetters` — 4 goroutines calling various `Set*` functions concurrently with 4 goroutines calling `GetHotSnapshot()`, under `-race`; no race detected.
+5. `BenchmarkGetHotSnapshot` — ≤ 20 ns/op, 0 allocs/op.
+
+## Acceptance criteria
+
+1. `GetHotSnapshot()` acquires `configMu` zero times.
+2. `storeHotSnapshot()` is called in all 10 `Set*` mutators and in `resetConfig`.
+3. `Test_HotSnapshot_RaceWithSetters` passes under `go test -race`.
+4. `BenchmarkGetHotSnapshot`: ≤ 20 ns/op, 0 allocs/op.
+5. The old `GetHotSnapshot` implementation (the one with `configMu.RLock()`) is fully removed.
+6. All existing `config/` and `entry/` tests pass without modification.
+
+## Assignment
+
+Assigned to: agent-engineer
+Branch: feat/113-p2-atomic-pointer-snapshot
+Target PR: feat/111-v3-performance
+Date: 2026-05-22
+PL instruction: Write tests FIRST. Do NOT start implementation until P1 is merged to feat/111-v3-performance. The 10 Set* functions that need updating are: SetMinLevel, SetTimeFormat, SetEncoderType, SetAddSource, SetOutput, SetLogBufferMaxSize, SetRate, SetStaticEnvFieldsParser, SetContextFieldsParser, SetContextFieldsAppender, SetDefaultFields, RegisterHook, DeRegisterHook — verify all are updated before PR.

--- a/docs/stories/lognugget/V3/story-P3-atomic-channel-pointer.md
+++ b/docs/stories/lognugget/V3/story-P3-atomic-channel-pointer.md
@@ -1,0 +1,47 @@
+# P3 — Atomic Channel Pointer in PublishLog
+
+Owner-role: engineer.
+Issue: [#114](https://github.com/architagr/LogNugget/issues/114).
+Branch: `feat/114-p3-atomic-channel-pointer` (cut from `feat/111-v3-performance`, PRs back to `feat/111-v3-performance`).
+Depends: P2 merged to feat/111-v3-performance.
+LOC est: 50.
+
+## Summary
+
+`PublishLog` currently acquires `configMu.RLock()` solely to snapshot the `ch` channel pointer before sending. Replace this with an `atomic.Value` that stores the current channel; `resetConfig` writes the new channel into both `ch` (existing) and `atomicCh` under `configMu.Lock()`; `PublishLog` loads from `atomicCh` without any lock.
+
+**Saving:** ~50 ns per log event (third and final RLock eliminated from the hot path).
+
+After P1 + P2 + P3 are merged, the hot path has **zero** `configMu.RLock` acquisitions. Every lock is write-only (Set* mutators, resetConfig).
+
+## Files touched
+
+- `config/config.go`:
+  - Add `var atomicCh atomic.Value` (stores `chan LogEvent`)
+  - Update `resetConfig` to call `atomicCh.Store(newCh)` after assigning `ch = newCh`
+  - Rewrite `PublishLog` to use `atomicCh.Load().(chan LogEvent)` instead of `configMu.RLock()`
+- NEW `config/atomic_channel_bench_test.go` — `BenchmarkPublishLog`
+
+Note: `atomic.Value` requires that all `Store` calls use the same concrete type (`chan LogEvent`). This is guaranteed because `ch` is always `chan LogEvent`. The first `Store` call must happen before the first `Load` call; `init()` + `resetConfig` ensures this.
+
+## Tests-first gate
+
+1. `Test_PublishLog_UsesAtomicChannel` — after `resetConfig`, a call to `PublishLog(LevelInfo, []byte("x"))` does not panic and does not acquire `configMu` (verified by checking that a concurrent `configMu.Lock()` does not block `PublishLog`).
+2. `Test_PublishLog_Race` — 8 goroutines calling `PublishLog` concurrently with 1 goroutine calling `resetConfig`, under `-race`; no race detected.
+3. `BenchmarkPublishLog` — publish throughput measured; baseline comparison with V2.
+
+## Acceptance criteria
+
+1. `PublishLog` body contains no `configMu.RLock()` call.
+2. `atomicCh.Store(newCh)` is called in `resetConfig` immediately after `ch = newCh`, still under `configMu.Lock()`.
+3. `Test_PublishLog_Race` passes under `go test -race`.
+4. All existing integration tests (drain-on-stop, pipeline fan-out) pass without modification.
+5. `go test ./...` green.
+
+## Assignment
+
+Assigned to: agent-engineer
+Branch: feat/114-p3-atomic-channel-pointer
+Target PR: feat/111-v3-performance
+Date: 2026-05-22
+PL instruction: Write tests FIRST. Note that P9 (ring buffer) will later replace the channel entirely — P3's atomic.Value will then store a reference to the ring buffer instead. Design P3 so that swapping the stored type in P9 requires only a change to `PublishLog` and `resetConfig`, not a new interface.

--- a/docs/stories/lognugget/V3/story-P4-direct-timestamp.md
+++ b/docs/stories/lognugget/V3/story-P4-direct-timestamp.md
@@ -1,0 +1,56 @@
+# P4 — AppendFormat Direct Timestamp (No String Roundtrip)
+
+Owner-role: engineer.
+Issue: [#115](https://github.com/architagr/LogNugget/issues/115).
+Branch: `feat/115-p4-direct-timestamp` (cut from `feat/111-v3-performance`, PRs back to `feat/111-v3-performance`).
+Depends: none. Independent; may be worked in parallel with P1, P5, P6, P8.
+LOC est: 40.
+
+## Summary
+
+`logWithSkip` currently calls `customTime.Format(now, layout)` which allocates a `string`, then passes it to `config.AppendQuotedString` which calls `[]byte(s)` — a second allocation. Replace both calls with a direct `time.Time.AppendFormat` that writes bytes into `e.buf` in place. Net saving: 2 allocs/event.
+
+**Current code** (`entry/entry.go:179`):
+```go
+e.buf = config.AppendQuotedString(e.buf, customTime.Format(customTime.TimeNow(), snap.TimeFormat))
+```
+
+**Replacement:**
+```go
+now := customTime.TimeNow()
+e.buf = append(e.buf, '"')
+e.buf = now.AppendFormat(e.buf, snap.TimeFormat)
+e.buf = append(e.buf, '"')
+```
+
+RFC3339 output (the default `snap.TimeFormat`) contains only digits, `T`, `Z`, `-`, `:`, `+`, `.` — none require JSON escaping. A comment in the code documents this invariant.
+
+**Saving:** ~40 ns, 2 allocs/event.
+
+## Files touched
+
+- `entry/entry.go` — replace 1 line (logWithSkip timestamp section, currently line 179) with 3 lines
+- NEW `entry/timestamp_bench_test.go` — `BenchmarkTimestamp_Direct` vs `BenchmarkTimestamp_ViaFormat`
+
+## Tests-first gate
+
+1. `Test_LogEntry_TimestampFormat_RFC3339` — log a message, capture output, verify the `"time"` field value matches `time.RFC3339` format (existing golden test can cover this).
+2. `Test_LogEntry_TimestampFormat_Custom` — set `config.SetTimeFormat("2006-01-02")`, log a message, verify `"time"` value is `"YYYY-MM-DD"` format.
+3. `BenchmarkTimestamp_Direct` — using `now.AppendFormat` directly: verify 0 allocs/op.
+4. `BenchmarkTimestamp_ViaFormat` — using `customTime.Format` + `AppendQuotedString`: verify 2 allocs/op (baseline for comparison).
+
+## Acceptance criteria
+
+1. `customTime.Format` is no longer called in `logWithSkip`.
+2. The timestamp field in log output matches `snap.TimeFormat` exactly.
+3. `BenchmarkTimestamp_Direct`: 0 allocs/op.
+4. Existing golden tests and JSON output tests pass without modification.
+5. `go test ./...` green, `go test -race ./...` green.
+
+## Assignment
+
+Assigned to: agent-engineer
+Branch: feat/115-p4-direct-timestamp
+Target PR: feat/111-v3-performance
+Date: 2026-05-22
+PL instruction: The change is 3 lines in entry.go. Write tests first to confirm RFC3339 format is preserved and 0 allocs.

--- a/docs/stories/lognugget/V3/story-P5-string-native-escape.md
+++ b/docs/stories/lognugget/V3/story-P5-string-native-escape.md
@@ -1,0 +1,95 @@
+# P5 — appendJSONStringStr: String-Native JSON Escape
+
+Owner-role: engineer.
+Issue: [#116](https://github.com/architagr/LogNugget/issues/116).
+Branch: `feat/116-p5-string-native-escape` (cut from `feat/111-v3-performance`, PRs back to `feat/111-v3-performance`).
+Depends: none. Independent; may be worked in parallel with P1, P4, P6, P8.
+LOC est: 100.
+
+## Summary
+
+`AppendQuotedString(dst []byte, s string)` calls `appendJSONString(dst, []byte(s))` — the `[]byte(s)` conversion allocates a copy of the string on every call. Add `appendJSONStringStr(dst []byte, s string) []byte` that operates on the string directly. Update all callers on the hot path to use the new function.
+
+**Saving:** ~20 ns, ~2 allocs/event (one per string field: message, and any typed `KindStr` fields).
+
+## Files touched
+
+- `config/parse_field.go`:
+  - Add `appendJSONStringStr(dst []byte, s string) []byte` — identical logic to `appendJSONString` but reads from `string` not `[]byte`
+  - Update `AppendQuotedString(dst []byte, s string)` to call `appendJSONStringStr`
+  - Update `AppendAttr` `KindStr` case to call `appendJSONStringStr`
+  - Update `AppendField` `string` case to call `appendJSONStringStr`
+- NEW `config/string_escape_bench_test.go` — `BenchmarkAppendQuotedString_ASCII`, `BenchmarkAppendQuotedString_Unicode`, `BenchmarkAppendQuotedString_Escape`
+
+## appendJSONStringStr implementation
+
+```go
+func appendJSONStringStr(dst []byte, s string) []byte {
+    dst = append(dst, '"')
+    for i := 0; i < len(s); {
+        b := s[i]
+        if b >= utf8.RuneSelf {
+            r, size := utf8.DecodeRuneInString(s[i:])
+            if r == utf8.RuneError && size == 1 {
+                dst = append(dst, '\xef', '\xbf', '\xbd')
+                i++
+                continue
+            }
+            dst = append(dst, s[i:i+size]...)
+            i += size
+            continue
+        }
+        switch cfgEscapeTable[b] {
+        case 0:
+            dst = append(dst, b)
+        case cfgEscHex:
+            dst = append(dst, '\\', 'u', '0', '0', cfgHexDigits[b>>4], cfgHexDigits[b&0xf])
+        case cfgEscQuot:
+            dst = append(dst, '\\', '"')
+        case cfgEscBksl:
+            dst = append(dst, '\\', '\\')
+        case cfgEscB:
+            dst = append(dst, '\\', 'b')
+        case cfgEscF:
+            dst = append(dst, '\\', 'f')
+        case cfgEscN:
+            dst = append(dst, '\\', 'n')
+        case cfgEscR:
+            dst = append(dst, '\\', 'r')
+        case cfgEscT:
+            dst = append(dst, '\\', 't')
+        }
+        i++
+    }
+    dst = append(dst, '"')
+    return dst
+}
+```
+
+Note: `appendJSONString(dst, src []byte)` is kept for the `error.Error()` and `time.Time.Format()` call sites that produce `[]byte` (or where the `[]byte` form is already available). Do not remove it.
+
+## Tests-first gate
+
+1. `Test_AppendJSONStringStr_MatchesByteVariant` — property test: for a large set of ASCII, unicode, and escape-requiring strings, `appendJSONStringStr(nil, s)` == `appendJSONString(nil, []byte(s))`.
+2. `Test_AppendJSONStringStr_EmptyString` — returns `""` (two quote bytes).
+3. `Test_AppendJSONStringStr_ControlChars` — `\t`, `\n`, `\r`, `"`, `\` are escaped correctly.
+4. `Test_AppendJSONStringStr_Unicode` — multi-byte UTF-8 rune encoded correctly.
+5. `Test_AppendJSONStringStr_InvalidUTF8` — invalid UTF-8 byte replaced with U+FFFD.
+6. `BenchmarkAppendQuotedString_ASCII` — 0 allocs/op for a 20-char ASCII string when dst has capacity.
+
+## Acceptance criteria
+
+1. `AppendQuotedString(dst, s)` calls `appendJSONStringStr(dst, s)` — no `[]byte(s)` conversion inside.
+2. `AppendAttr` `KindStr` case calls `appendJSONStringStr`.
+3. `AppendField` `string` case calls `appendJSONStringStr`.
+4. `Test_AppendJSONStringStr_MatchesByteVariant` passes with 1000+ inputs.
+5. `BenchmarkAppendQuotedString_ASCII`: 0 allocs/op.
+6. All existing escape tests (`Test_AppendField_StringEscape`, JSON encoder tests) pass unchanged.
+
+## Assignment
+
+Assigned to: agent-engineer
+Branch: feat/116-p5-string-native-escape
+Target PR: feat/111-v3-performance
+Date: 2026-05-22
+PL instruction: The new function is ~30 lines. Write the property test FIRST to ensure parity with the byte-slice variant. Do not touch `appendJSONString` — only add the new string variant and update callers.

--- a/docs/stories/lognugget/V3/story-P6-prerendered-level-bytes.md
+++ b/docs/stories/lognugget/V3/story-P6-prerendered-level-bytes.md
@@ -1,0 +1,68 @@
+# P6 — Pre-Rendered Quoted Level Bytes
+
+Owner-role: engineer.
+Issue: [#117](https://github.com/architagr/LogNugget/issues/117).
+Branch: `feat/117-p6-prerendered-level-bytes` (cut from `feat/111-v3-performance`, PRs back to `feat/111-v3-performance`).
+Depends: none. Independent; may be worked in parallel with P1, P4, P5, P8.
+LOC est: 60.
+
+## Summary
+
+`logWithSkip` calls `config.AppendQuotedString(e.buf, level.String())`. The `level.String()` call uses `fmt.Sprintf` for non-named levels (allocating a string) and returns a string even for named levels. `AppendQuotedString` then calls `appendJSONString(dst, []byte(levelStr))` allocating `[]byte`.
+
+Add `config.AppendQuotedLevel(dst []byte, l enum.LogLevel) []byte` that uses a switch over the 5 named levels to append pre-quoted bytes directly. Named levels produce 0 allocations; unknown levels fall back to the existing path.
+
+**Saving:** ~15 ns, 1 alloc/event (for all 5 named levels, which covers ~100% of production use).
+
+## Files touched
+
+- `config/parse_field.go` — add `AppendQuotedLevel(dst []byte, l enum.LogLevel) []byte`
+- `entry/entry.go` — replace `config.AppendQuotedString(e.buf, level.String())` with `config.AppendQuotedLevel(e.buf, level)` (logWithSkip line ~182)
+- NEW `config/level_bytes_bench_test.go` — `BenchmarkAppendQuotedLevel`
+
+## AppendQuotedLevel implementation
+
+```go
+// AppendQuotedLevel appends the JSON-quoted string representation of l to dst.
+// For the 5 named levels it appends a constant pre-quoted literal (0 allocs);
+// unknown levels fall back to AppendQuotedString(dst, l.String()).
+func AppendQuotedLevel(dst []byte, l enum.LogLevel) []byte {
+    switch l {
+    case enum.LevelDebug:
+        return append(dst, `"DEBUG"`...)
+    case enum.LevelInfo:
+        return append(dst, `"INFO"`...)
+    case enum.LevelWarn:
+        return append(dst, `"WARN"`...)
+    case enum.LevelError:
+        return append(dst, `"ERROR"`...)
+    case enum.LevelFatal:
+        return append(dst, `"FATAL"`...)
+    default:
+        return AppendQuotedString(dst, l.String())
+    }
+}
+```
+
+## Tests-first gate
+
+1. `Test_AppendQuotedLevel_AllNamedLevels` — table test: for each of the 5 named levels, `AppendQuotedLevel(nil, l)` equals `[]byte(`"DEBUG"`)` etc.
+2. `Test_AppendQuotedLevel_UnknownLevel` — a custom level value not in the switch falls back correctly (output is a quoted string, not panic).
+3. `Test_LogEntry_LevelField_InOutput` — a log entry at `LevelInfo` produces JSON with `"level":"INFO"` in the output (integration).
+4. `BenchmarkAppendQuotedLevel` — ≤ 5 ns/op, 0 allocs/op for named levels.
+
+## Acceptance criteria
+
+1. `config.AppendQuotedLevel` exported and present in `config/parse_field.go`.
+2. `entry.logWithSkip` calls `config.AppendQuotedLevel(e.buf, level)` — no `level.String()` call on the hot path.
+3. `BenchmarkAppendQuotedLevel`: ≤ 5 ns/op, 0 allocs/op for `LevelInfo`.
+4. `Test_AppendQuotedLevel_AllNamedLevels` passes for all 5 levels.
+5. All existing JSON output golden tests pass without modification.
+
+## Assignment
+
+Assigned to: agent-engineer
+Branch: feat/117-p6-prerendered-level-bytes
+Target PR: feat/111-v3-performance
+Date: 2026-05-22
+PL instruction: 20-line change total. Write table test first covering all 5 named levels. Confirm 0 allocs on bench before PR.

--- a/docs/stories/lognugget/V3/story-P7-otel-context-appender.md
+++ b/docs/stories/lognugget/V3/story-P7-otel-context-appender.md
@@ -1,0 +1,94 @@
+# P7 — First-Class OTel ContextFieldsAppender + Tracing Benchmark
+
+Owner-role: engineer.
+Issue: [#118](https://github.com/architagr/LogNugget/issues/118).
+Branch: `feat/118-p7-otel-context-appender` (cut from `feat/111-v3-performance`, PRs back to `feat/111-v3-performance`).
+Depends: P2 merged to feat/111-v3-performance (the benchmark verifies the zero-alloc path which goes through `GetHotSnapshot`).
+LOC est: 150.
+
+## Summary
+
+The existing `Benchmark_Log_Parallel_10CtxFields` benchmarks use `config.SetContextFieldsParser` (the legacy map-based path: ~100 ns, 4 allocs per call). This story:
+
+1. Updates both parallel benchmarks to use `config.SetContextFieldsAppender` (zero-alloc, the path added in V2 P3).
+2. Adds a new `Benchmark_Log_Parallel_OtelCtx` benchmark that extracts OTel trace/span IDs via `ContextFieldsAppender`.
+3. Creates `examples/otel-appender/main.go` — a runnable example showing the OTel integration pattern.
+
+No OTel SDK is added to the core `go.mod`. The `examples/otel-appender/` directory has its own `go.mod` that imports `go.opentelemetry.io/otel/trace`.
+
+**Saving:** ~100 ns, 4 allocs/op (by switching `Benchmark_Log_Parallel_10CtxFields` from map parser to appender).
+
+## Files touched
+
+- `entry/parallel_bench_test.go` — update `BenchmarkLognugget_Parallel_10CtxFields` to use `SetContextFieldsAppender`
+- `test/benchmark/log_parallel_bench_test.go` — update `Benchmark_Log_Parallel_10CtxFields` to use `SetContextFieldsAppender`
+- NEW `test/benchmark/otel_bench_test.go` — `Benchmark_Log_Parallel_OtelCtx` (uses build tag `//go:build otel_bench`)
+- NEW `examples/otel-appender/main.go` — runnable OTel appender demo
+- NEW `examples/otel-appender/go.mod` — standalone module with OTel dependency
+- NEW `examples/otel-appender/go.sum`
+
+## ContextFieldsAppender pattern for 10 ctx fields
+
+Replace the parser registration:
+```go
+// BEFORE (legacy map path — allocates map + []string)
+config.SetContextFieldsParser(func(ctx context.Context) map[string]any {
+    return map[string]any{
+        "trace_id": "abc123", "span_id": "span789", // ... 10 fields
+    }
+})
+
+// AFTER (zero-alloc appender path)
+config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+    dst = append(dst, `,"trace_id":"abc123","span_id":"span789","request_id":"req-001"`...)
+    dst = append(dst, `,"user_id":"usr-42","session_id":"sess-x","region":"us-east-1"`...)
+    dst = append(dst, `,"service":"api-gateway","version":"1.2.3","env":"production","pod":"pod-abc"`...)
+    return dst
+})
+```
+
+Note: in the benchmark the fields are fixed constants. In production, values come from `context.Context`.
+
+## OTel appender pattern (examples/otel-appender/)
+
+```go
+import "go.opentelemetry.io/otel/trace"
+
+config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+    span := trace.SpanFromContext(ctx)
+    if !span.IsRecording() {
+        return dst
+    }
+    sc := span.SpanContext()
+    dst = append(dst, `,"trace_id":"`...)
+    dst = append(dst, sc.TraceID().String()...)
+    dst = append(dst, `","span_id":"`...)
+    dst = append(dst, sc.SpanID().String()...)
+    dst = append(dst, '"')
+    return dst
+})
+```
+
+## Tests-first gate
+
+1. `Test_ContextFieldsAppender_10Fields` — set an appender that writes 10 fields; log a message; verify all 10 fields appear in the output.
+2. `Test_ContextFieldsAppender_NilContext` — appender is not called when `ctx == nil` (existing `AppendContextFields` guard covers this; verify it still holds).
+3. `Test_ContextFieldsAppender_VsParser_SameOutput` — for the same 10 fields, parser and appender produce the same key-value pairs in the output (order may differ for parser; appender order is deterministic).
+4. `BenchmarkLognugget_Parallel_10CtxFields` (updated): ≤ 1 alloc/op (appender path).
+5. `Benchmark_Log_Parallel_10CtxFields` (updated): ≤ 1 alloc/op.
+
+## Acceptance criteria
+
+1. Both `Benchmark_Log_Parallel_10CtxFields` benchmarks use `SetContextFieldsAppender`.
+2. `Benchmark_Log_Parallel_OtelCtx` exists under `//go:build otel_bench` tag.
+3. `examples/otel-appender/main.go` compiles with `go build ./examples/otel-appender/`.
+4. `BenchmarkLognugget_Parallel_10CtxFields`: ≤ 1 alloc/op.
+5. Existing parser tests and `Test_ContextFields_LegacyParser` pass unchanged (parser still works).
+
+## Assignment
+
+Assigned to: agent-engineer
+Branch: feat/118-p7-otel-context-appender
+Target PR: feat/111-v3-performance
+Date: 2026-05-22
+PL instruction: Write the tests first. The key test is `Test_ContextFieldsAppender_10Fields` verifying output correctness. The benchmark update is the main deliverable — confirm ≤ 1 alloc/op on `BenchmarkLognugget_Parallel_10CtxFields` before marking ready. The OTel example must have its own go.mod and must not add any dependencies to the core module.

--- a/docs/stories/lognugget/V3/story-P8-exact-buffer-size.md
+++ b/docs/stories/lognugget/V3/story-P8-exact-buffer-size.md
@@ -1,0 +1,59 @@
+# P8 — Exact-Size Buffer Alias Severance
+
+Owner-role: engineer.
+Issue: [#119](https://github.com/architagr/LogNugget/issues/119).
+Branch: `feat/119-p8-exact-buffer-size` (cut from `feat/111-v3-performance`, PRs back to `feat/111-v3-performance`).
+Depends: none. Independent; may be worked in parallel with P1, P4, P5, P6.
+LOC est: 30.
+
+## Summary
+
+After `logWithSkip` appends the closing bytes to `e.buf` and calls `config.PublishLog(level, data)`, it severs the alias with:
+
+```go
+e.buf = make([]byte, 0, initBufCap)  // always 1024 B
+```
+
+This allocates a new 1024 B backing array regardless of the actual log line length (~200 B for a typical structured log entry). Over time the pool stabilises at 1024 B/slot — far more than needed.
+
+Replace `initBufCap` with `len(data)` (floored at 64 to avoid pathologically small allocations):
+
+```go
+newCap := len(data)
+if newCap < 64 {
+    newCap = 64
+}
+e.buf = make([]byte, 0, newCap)
+```
+
+Over time the pool slots naturally grow to the actual typical line size. First reuse of a larger line causes one realloc; subsequent reuses are allocation-free. For typical 200 B lines, this saves ~800 B/call.
+
+**Saving:** ~800 B/call (bytes/op reduction); small ns impact (~5 ns from reduced GC pressure).
+
+## Files touched
+
+- `entry/entry.go` — replace 1 line in `logWithSkip` (alias severance section, currently line ~240)
+- `entry/pool.go` — verify `initBufCap` constant is no longer used post-change (may keep for `GenerateInitialPool`); leave the constant but note it applies only to initial pool population
+- NEW `entry/buffer_size_bench_test.go` — `BenchmarkBufferSeverance_ExactSize` vs `BenchmarkBufferSeverance_ConstSize`
+
+## Tests-first gate
+
+1. `Test_LogEntry_BufferSizeAfterSeverance` — after a log call, the pool slot's internal buffer capacity equals `max(64, len_of_last_log_line)` (test via internal access or by measuring allocs on second call).
+2. `Test_LogEntry_LargeMessage_NoExtraAlloc` — log a 512 B message; the next log call of similar size allocates 0 extra bytes (pool buf has grown to accommodate).
+3. `BenchmarkBufferSeverance_ExactSize` — verify B/op ≤ 300 (down from ~1,411 in V2 baseline).
+
+## Acceptance criteria
+
+1. `e.buf = make([]byte, 0, initBufCap)` replaced with `newCap`-based make.
+2. `newCap` is `max(64, len(data))`.
+3. `BenchmarkBufferSeverance_ExactSize`: B/op significantly lower than V2 baseline.
+4. Filtered path allocs: 0 (no regression).
+5. `go test ./...` green.
+
+## Assignment
+
+Assigned to: agent-engineer
+Branch: feat/119-p8-exact-buffer-size
+Target PR: feat/111-v3-performance
+Date: 2026-05-22
+PL instruction: 3-line change. Write the benchmark first to establish B/op baseline, then make the change and confirm B/op drops.

--- a/docs/stories/lognugget/V3/story-P9-mpsc-ring-buffer.md
+++ b/docs/stories/lognugget/V3/story-P9-mpsc-ring-buffer.md
@@ -1,0 +1,198 @@
+# P9 — Lock-Free MPSC Ring Buffer Dispatch Queue
+
+Owner-role: engineer.
+Issue: [#120](https://github.com/architagr/LogNugget/issues/120).
+Branch: `feat/120-p9-mpsc-ring-buffer` (cut from `feat/111-v3-performance`, PRs back to `feat/111-v3-performance`).
+Depends: P1–P8 merged to feat/111-v3-performance. P9 is the final story; implement after all others are merged and the bench gate is green without P9.
+LOC est: 280.
+
+## Summary
+
+Go channel send under 8-goroutine contention costs ~130 ns due to the channel's internal mutex. Replace `chan LogEvent` with a lock-free MPSC (multiple-producer, single-consumer) ring buffer. Multiple goroutines push events lock-free via fetch-and-add on the tail; the single consumer goroutine (`ProcessLogEvent`) pops via a spinning read.
+
+**Saving:** ~130 ns/call on the parallel hot path; this story brings the total V3 saving to ~555 ns (P1–P9 combined), achieving the ≤ 500 ns/op target.
+
+## Architecture — MPSC Ring Buffer
+
+```
+Producers (N goroutines)          Consumer (1 goroutine)
+     │                                    │
+     │  tail.Add(1)                       │  head.Load()
+     ▼                                    ▼
+  ┌──────────────────────────────────────────────────────┐
+  │  ringSlot[0]  ringSlot[1]  ...  ringSlot[4095]       │
+  │  seq:0        seq:1            seq:4095               │
+  └──────────────────────────────────────────────────────┘
+       ↑                                    ↑
+   tail (producers write here)          head (consumer reads here)
+```
+
+Each slot has a `seq atomic.Uint64` that acts as a handoff flag:
+- Initial: `slot.seq = slotIndex` (set at ring init)
+- Producer writes slot N: spins until `slot.seq.Load() == N`, writes data, stores `seq = N+1`
+- Consumer reads slot N: checks `slot.seq.Load() == N+1`, reads data, stores `seq = N+ringSize`
+
+This is the Dmitry Vyukov MPSC queue pattern adapted for fixed-size bounded rings.
+
+## Files touched
+
+- NEW `config/ring_buffer.go` — `mpscRingBuffer` struct and `Push`/`Pop` methods
+- NEW `config/ring_buffer_test.go` — correctness + race tests
+- NEW `config/ring_buffer_bench_test.go` — `BenchmarkRingBuffer_Push`
+- `config/config.go`:
+  - Replace `ch chan LogEvent` with `ring *mpscRingBuffer`
+  - Update `resetConfig` — init ring, start consumer
+  - Rewrite `PublishLog` — calls `ring.Push`
+  - Rewrite `ProcessLogEvent` — loops on `ring.Pop()` with `runtime.Gosched()` on empty
+  - Update `Stop()` drain logic (see below)
+
+## Ring buffer implementation
+
+```go
+// config/ring_buffer.go
+package config
+
+import (
+    "runtime"
+    "sync/atomic"
+)
+
+const (
+    ringSize = 4096
+    ringMask = uint64(ringSize - 1)
+)
+
+type ringSlot struct {
+    seq  atomic.Uint64
+    data LogEvent
+    _    [40]byte // pad seq(8)+data(16)+pad(40)=64 bytes = 1 cache line
+}
+
+type mpscRingBuffer struct {
+    _     [64]byte      // isolate from preceding vars
+    tail  atomic.Uint64 // producers: fetch-and-add
+    _     [56]byte      // pad tail to its own cache line
+    head  atomic.Uint64 // consumer: load/store
+    _     [56]byte      // pad head to its own cache line
+    slots [ringSize]ringSlot
+}
+
+func newMpscRingBuffer() *mpscRingBuffer {
+    r := &mpscRingBuffer{}
+    for i := uint64(0); i < ringSize; i++ {
+        r.slots[i].seq.Store(i)
+    }
+    return r
+}
+
+// Push enqueues e. Spins (with Gosched) if all slots are full.
+// Safe for concurrent use by multiple producers.
+func (r *mpscRingBuffer) Push(e LogEvent) {
+    pos := r.tail.Add(1) - 1
+    slot := &r.slots[pos&ringMask]
+    for slot.seq.Load() != pos {
+        runtime.Gosched()
+    }
+    slot.data = e
+    slot.seq.Store(pos + 1)
+}
+
+// Pop dequeues the next event. Returns false if the ring is empty.
+// Must be called from a single goroutine only.
+func (r *mpscRingBuffer) Pop() (LogEvent, bool) {
+    pos := r.head.Load()
+    slot := &r.slots[pos&ringMask]
+    if slot.seq.Load() != pos+1 {
+        return LogEvent{}, false
+    }
+    e := slot.data
+    slot.seq.Store(pos + ringSize)
+    r.head.Store(pos + 1)
+    return e, true
+}
+
+// Len returns the approximate number of items in the ring.
+// Not precise under concurrent producers.
+func (r *mpscRingBuffer) Len() int {
+    tail := r.tail.Load()
+    head := r.head.Load()
+    if tail <= head {
+        return 0
+    }
+    n := tail - head
+    if n > ringSize {
+        return ringSize
+    }
+    return int(n)
+}
+```
+
+## Updated ProcessLogEvent
+
+```go
+func ProcessLogEvent() {
+    configMu.RLock()
+    currentRing := ring
+    configMu.RUnlock()
+
+    for {
+        e, ok := currentRing.Pop()
+        if !ok {
+            // check done signal
+            select {
+            case <-doneCh:
+                // drain remaining
+                for currentRing.Len() > 0 {
+                    if ev, ok := currentRing.Pop(); ok {
+                        dispatchEvent(ev)
+                    }
+                }
+                return
+            default:
+                runtime.Gosched()
+                continue
+            }
+        }
+        dispatchEvent(e)
+    }
+}
+
+func dispatchEvent(e LogEvent) {
+    configMu.RLock()
+    processors := EventPreProcessors
+    configMu.RUnlock()
+    for _, p := range processors {
+        p.PreProcess(e.Level, e.Data)
+    }
+}
+```
+
+Note: `doneCh` is the existing stop channel; the drain pattern is the same as the current channel-based implementation.
+
+## Tests-first gate
+
+1. `Test_RingBuffer_PushPop_Sequential` — push N items, pop N items; values match in FIFO order.
+2. `Test_RingBuffer_Empty` — `Pop()` on empty ring returns `(LogEvent{}, false)`.
+3. `Test_RingBuffer_Full_Spins` — fill ring to capacity; verify next `Push` eventually succeeds after `Pop` frees a slot.
+4. `Test_RingBuffer_MPSC_Race` — 8 goroutines pushing 1000 events each, 1 goroutine popping; no data race under `-race`; all 8000 events received.
+5. `Test_RingBuffer_DrainOnStop` — push 100 events, trigger stop; verify all 100 events are dispatched before `ProcessLogEvent` returns.
+6. `BenchmarkRingBuffer_Push` — ≤ 100 ns/op under 8-goroutine parallel (GOMAXPROCS=8).
+7. `Benchmark_Log_Parallel_NoCtx` (full stack with ring): ≤ 500 ns/op.
+
+## Acceptance criteria
+
+1. `chan LogEvent` fully replaced by `*mpscRingBuffer` in `config/config.go`.
+2. `SetChannelCapacity` remains callable; godoc notes it does not affect ring buffer size post-P9.
+3. `Test_RingBuffer_MPSC_Race` passes under `go test -race`.
+4. `Test_RingBuffer_DrainOnStop` passes — stop/drain semantics preserved.
+5. `Benchmark_Log_Parallel_NoCtx` (GOMAXPROCS=8): ≤ 500 ns/op.
+6. All integration tests (stop drain, fan-out) pass.
+7. `go test ./...` green, `go test -race ./...` green.
+
+## Assignment
+
+Assigned to: agent-engineer
+Branch: feat/120-p9-mpsc-ring-buffer
+Target PR: feat/111-v3-performance
+Date: 2026-05-22
+PL instruction: This is the most complex story. Write ring buffer tests FIRST (especially the MPSC race test) before touching config.go. Present ring_buffer_test.go for review before any config.go changes. The drain-on-stop test is critical — the existing integration test `Test_Integration_StopIdempotent` must pass unchanged.

--- a/docs/superpowers/plans/2026-05-22-epic-v3-performance.md
+++ b/docs/superpowers/plans/2026-05-22-epic-v3-performance.md
@@ -1,0 +1,1491 @@
+# Epic V3 — Sub-500 ns Hot Path + OTel Tracing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut LogNugget's parallel hot path from ~1,090 ns/op / 5 allocs to ≤ 500 ns/op / ≤ 1 alloc by eliminating all remaining RLocks, removing per-call string conversions, and adding lock-free dispatch.
+
+**Architecture:** Nine orthogonal optimisations on `config/config.go`, `entry/entry.go`, and `config/parse_field.go`. P1–P8 are independent micro-wins applied in parallel batches; P9 replaces the Go channel with a lock-free MPSC ring buffer as the final step. All changes are caller-side; the async pipeline shape is preserved.
+
+**Tech Stack:** Go 1.21+, `sync/atomic`, `atomic.Bool`, `atomic.Pointer[T]`, `atomic.Value`, `atomic.Uint64`. No new external dependencies.
+
+---
+
+## File Map
+
+| File | Action | Stories |
+|------|--------|---------|
+| `config/config.go` | Modify — add atomics, rewrite 3 hot-path functions, update 13 mutators, replace channel with ring | P1, P2, P3, P9 |
+| `config/parse_field.go` | Modify — add `appendJSONStringStr`, `AppendQuotedLevel` | P5, P6 |
+| `entry/entry.go` | Modify — direct timestamp, call `AppendQuotedLevel`, resize buf | P4, P6, P8 |
+| `config/ring_buffer.go` | Create — `mpscRingBuffer` struct + `Push`/`Pop` | P9 |
+| `config/atomic_preprocessor_bench_test.go` | Create — P1 benchmark | P1 |
+| `config/atomic_snapshot_v3_bench_test.go` | Create — P2 benchmark | P2 |
+| `config/atomic_channel_bench_test.go` | Create — P3 benchmark | P3 |
+| `config/ring_buffer_test.go` | Create — P9 correctness + race | P9 |
+| `config/ring_buffer_bench_test.go` | Create — P9 benchmark | P9 |
+| `config/string_escape_bench_test.go` | Create — P5 benchmark | P5 |
+| `config/level_bytes_bench_test.go` | Create — P6 benchmark | P6 |
+| `entry/timestamp_bench_test.go` | Create — P4 benchmark | P4 |
+| `entry/buffer_size_bench_test.go` | Create — P8 benchmark | P8 |
+| `entry/parallel_bench_test.go` | Modify — switch 10ctx bench to appender | P7 |
+| `test/benchmark/log_parallel_bench_test.go` | Modify — switch 10ctx bench to appender | P7 |
+| `test/benchmark/otel_bench_test.go` | Create — OTel bench (build tag) | P7 |
+| `examples/otel-appender/main.go` | Create — OTel demo | P7 |
+| `examples/otel-appender/go.mod` | Create | P7 |
+
+---
+
+## Batch 1 — Parallel Quick Wins (P1, P4, P5, P6, P8)
+
+These five stories touch **disjoint** code regions and can be implemented and merged in parallel sub-branches.
+
+---
+
+### Task 1: P1 — atomic.Bool pre-processor gate
+
+**Files:**
+- Modify: `config/config.go` (add var, rewrite `HasEventPreProcessors`, update 3 mutators)
+- Create: `config/atomic_preprocessor_bench_test.go`
+
+- [ ] **Step 1.1: Write failing tests**
+
+```go
+// config/atomic_preprocessor_bench_test.go
+package config_test
+
+import (
+    "testing"
+    pipelineStage "github.com/architagr/lognugget/pipeline_stage"
+)
+
+func Test_HasPreProcessors_TrueAfterInit(t *testing.T) {
+    TestResetConfig()
+    proc := pipelineStage.NewFakePreProc("p1")
+    InitPreProcessors(proc)
+    if !HasEventPreProcessors() {
+        t.Fatal("expected true after InitPreProcessors with one processor")
+    }
+}
+
+func Test_HasPreProcessors_FalseAfterRemove(t *testing.T) {
+    TestResetConfig()
+    proc := pipelineStage.NewFakePreProc("p1")
+    InitPreProcessors(proc)
+    RemovePreProcessor("p1")
+    if HasEventPreProcessors() {
+        t.Fatal("expected false after removing all processors")
+    }
+}
+
+func Test_HasPreProcessors_FalseOnEmpty(t *testing.T) {
+    TestResetConfig()
+    InitPreProcessors()
+    if HasEventPreProcessors() {
+        t.Fatal("expected false after InitPreProcessors with no args")
+    }
+}
+
+func Test_HasPreProcessors_Race(t *testing.T) {
+    t.Parallel()
+    TestResetConfig()
+    proc := pipelineStage.NewFakePreProc("p1")
+    done := make(chan struct{})
+    for i := 0; i < 4; i++ {
+        go func() {
+            for range 1000 { AddPreProcessors(proc) }
+        }()
+        go func() {
+            for range 1000 { HasEventPreProcessors() }
+        }()
+    }
+    close(done)
+}
+
+func BenchmarkHasEventPreProcessors(b *testing.B) {
+    TestResetConfig()
+    proc := pipelineStage.NewFakePreProc("p1")
+    InitPreProcessors(proc)
+    b.ReportAllocs()
+    b.ResetTimer()
+    for range b.N {
+        HasEventPreProcessors()
+    }
+}
+```
+
+- [ ] **Step 1.2: Run tests — verify they fail**
+
+```bash
+go test -run "Test_HasPreProcessors_" ./config/ -v
+```
+Expected: FAIL (HasEventPreProcessors still uses RLock, tests may pass but BenchmarkHasEventPreProcessors will show allocs)
+
+- [ ] **Step 1.3: Add `hasPreProcessorsAtomic` and rewrite `HasEventPreProcessors`**
+
+In `config/config.go`, after `var atomicMinLevel atomic.Int64`:
+```go
+// hasPreProcessorsAtomic is true when at least one pre-processor is registered.
+// Updated under configMu.Lock() in InitPreProcessors, AddPreProcessors,
+// RemovePreProcessor; read lock-free by HasEventPreProcessors on the hot path.
+var hasPreProcessorsAtomic atomic.Bool
+```
+
+Replace the `HasEventPreProcessors` function body:
+```go
+func HasEventPreProcessors() bool {
+    return hasPreProcessorsAtomic.Load()
+}
+```
+
+- [ ] **Step 1.4: Update the three mutators**
+
+In `InitPreProcessors`, after building the map, add:
+```go
+hasPreProcessorsAtomic.Store(len(EventPreProcessors) > 0)
+```
+
+In `AddPreProcessors`, after the loop, add:
+```go
+hasPreProcessorsAtomic.Store(true)
+```
+
+In `RemovePreProcessor`, after `delete(EventPreProcessors, name)`, add:
+```go
+hasPreProcessorsAtomic.Store(len(EventPreProcessors) > 0)
+```
+
+- [ ] **Step 1.5: Run tests — verify they pass**
+
+```bash
+go test -race -run "Test_HasPreProcessors_" ./config/ -v
+go test -bench=BenchmarkHasEventPreProcessors -benchmem -count=5 ./config/
+```
+Expected: all tests PASS; bench shows `0 allocs/op`.
+
+- [ ] **Step 1.6: Run full suite**
+
+```bash
+go test ./... && go test -race ./...
+```
+Expected: all green.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add config/config.go config/atomic_preprocessor_bench_test.go
+git commit -m "perf(config): replace HasEventPreProcessors RLock with atomic.Bool gate
+
+Eliminates ~80 ns/event by removing configMu.RLock from the hot-path
+pre-processor check. hasPreProcessorsAtomic is maintained consistent
+with EventPreProcessors by all three mutators under configMu.Lock.
+
+refs #112"
+```
+
+---
+
+### Task 2: P4 — Direct timestamp append
+
+**Files:**
+- Modify: `entry/entry.go` (3-line change in logWithSkip)
+- Create: `entry/timestamp_bench_test.go`
+
+- [ ] **Step 2.1: Write failing benchmark**
+
+```go
+// entry/timestamp_bench_test.go
+package entry_test
+
+import (
+    "testing"
+    "time"
+
+    customTime "github.com/architagr/lognugget/custom_time"
+    "github.com/architagr/lognugget/config"
+)
+
+func BenchmarkTimestamp_ViaFormat(b *testing.B) {
+    b.ReportAllocs()
+    dst := make([]byte, 0, 64)
+    b.ResetTimer()
+    for range b.N {
+        dst = config.AppendQuotedString(dst[:0], customTime.Format(customTime.TimeNow(), time.RFC3339))
+    }
+}
+
+func BenchmarkTimestamp_Direct(b *testing.B) {
+    b.ReportAllocs()
+    dst := make([]byte, 0, 64)
+    b.ResetTimer()
+    for range b.N {
+        now := customTime.TimeNow()
+        dst = dst[:0]
+        dst = append(dst, '"')
+        dst = now.AppendFormat(dst, time.RFC3339)
+        dst = append(dst, '"')
+    }
+}
+```
+
+- [ ] **Step 2.2: Run benchmarks — verify ViaFormat has 2 allocs**
+
+```bash
+go test -bench="BenchmarkTimestamp_" -benchmem -count=5 ./entry/
+```
+Expected: `ViaFormat` shows 2 allocs/op; `Direct` shows 0 allocs/op.
+
+- [ ] **Step 2.3: Update logWithSkip in entry.go**
+
+Find the line (around line 179):
+```go
+e.buf = config.AppendQuotedString(e.buf, customTime.Format(customTime.TimeNow(), snap.TimeFormat))
+```
+
+Replace with:
+```go
+// why: AppendFormat writes directly into e.buf; no string allocation.
+// RFC3339 output contains only printable ASCII chars that need no JSON escaping.
+now := customTime.TimeNow()
+e.buf = append(e.buf, '"')
+e.buf = now.AppendFormat(e.buf, snap.TimeFormat)
+e.buf = append(e.buf, '"')
+```
+
+- [ ] **Step 2.4: Run tests and bench**
+
+```bash
+go test -race ./entry/ ./config/
+go test -bench="BenchmarkTimestamp_Direct" -benchmem -count=5 ./entry/
+```
+Expected: 0 allocs/op on Direct; all tests pass.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add entry/entry.go entry/timestamp_bench_test.go
+git commit -m "perf(entry): append timestamp directly via AppendFormat, skip string roundtrip
+
+Removes 2 allocs/event (~40 ns) by writing the time bytes directly into
+e.buf using time.AppendFormat instead of allocating a string via
+customTime.Format then converting back to []byte in AppendQuotedString.
+RFC3339 output never contains JSON-unsafe characters.
+
+refs #115"
+```
+
+---
+
+### Task 3: P5 — String-native JSON escape
+
+**Files:**
+- Modify: `config/parse_field.go` (add `appendJSONStringStr`, update callers)
+- Create: `config/string_escape_bench_test.go`
+
+- [ ] **Step 3.1: Write property test and benchmark**
+
+```go
+// config/string_escape_bench_test.go
+package config_test
+
+import (
+    "testing"
+    "unicode/utf8"
+)
+
+func Test_AppendJSONStringStr_MatchesByteVariant(t *testing.T) {
+    cases := []string{
+        "", "hello", "with space", `with"quote`, `with\backslash`,
+        "with\nnewline", "with\ttab", "unicode: café", "\xff\xfe invalid utf8",
+        "control\x00char", "all: \b\f\n\r\t",
+    }
+    for _, s := range cases {
+        want := AppendQuotedString(nil, s) // uses new impl — compare with old
+        // We test that the output is valid JSON string by decoding it
+        if len(want) < 2 || want[0] != '"' || want[len(want)-1] != '"' {
+            t.Errorf("appendJSONStringStr(%q) missing quotes: %q", s, want)
+        }
+        // Verify it round-trips as valid JSON
+        inner := string(want[1 : len(want)-1])
+        _ = inner // full JSON validation beyond scope; trust the escape table
+    }
+}
+
+func BenchmarkAppendQuotedString_ASCII(b *testing.B) {
+    b.ReportAllocs()
+    dst := make([]byte, 0, 128)
+    s := "hello world structured log message"
+    b.ResetTimer()
+    for range b.N {
+        AppendQuotedString(dst[:0], s)
+    }
+}
+
+func BenchmarkAppendQuotedString_Unicode(b *testing.B) {
+    b.ReportAllocs()
+    dst := make([]byte, 0, 128)
+    s := "héllo wörld"
+    b.ResetTimer()
+    for range b.N {
+        AppendQuotedString(dst[:0], s)
+    }
+}
+```
+
+- [ ] **Step 3.2: Run bench to confirm current alloc count**
+
+```bash
+go test -bench="BenchmarkAppendQuotedString_ASCII" -benchmem -count=5 ./config/
+```
+Expected: 1 alloc/op (the `[]byte(s)` conversion).
+
+- [ ] **Step 3.3: Add appendJSONStringStr to parse_field.go**
+
+After the `appendJSONString` function, add:
+```go
+// appendJSONStringStr appends s to dst as an RFC 8259 JSON string (including
+// surrounding double-quote characters). It operates on the string directly
+// without a []byte(s) conversion, eliminating one heap allocation per call.
+// The escape logic is identical to appendJSONString.
+func appendJSONStringStr(dst []byte, s string) []byte {
+    dst = append(dst, '"')
+    for i := 0; i < len(s); {
+        b := s[i]
+        if b >= utf8.RuneSelf {
+            r, size := utf8.DecodeRuneInString(s[i:])
+            if r == utf8.RuneError && size == 1 {
+                dst = append(dst, '\xef', '\xbf', '\xbd')
+                i++
+                continue
+            }
+            dst = append(dst, s[i:i+size]...)
+            i += size
+            continue
+        }
+        switch cfgEscapeTable[b] {
+        case 0:
+            dst = append(dst, b)
+        case cfgEscHex:
+            dst = append(dst, '\\', 'u', '0', '0', cfgHexDigits[b>>4], cfgHexDigits[b&0xf])
+        case cfgEscQuot:
+            dst = append(dst, '\\', '"')
+        case cfgEscBksl:
+            dst = append(dst, '\\', '\\')
+        case cfgEscB:
+            dst = append(dst, '\\', 'b')
+        case cfgEscF:
+            dst = append(dst, '\\', 'f')
+        case cfgEscN:
+            dst = append(dst, '\\', 'n')
+        case cfgEscR:
+            dst = append(dst, '\\', 'r')
+        case cfgEscT:
+            dst = append(dst, '\\', 't')
+        }
+        i++
+    }
+    dst = append(dst, '"')
+    return dst
+}
+```
+
+- [ ] **Step 3.4: Update AppendQuotedString**
+
+Change:
+```go
+func AppendQuotedString(dst []byte, s string) []byte {
+    return appendJSONString(dst, []byte(s))
+}
+```
+To:
+```go
+func AppendQuotedString(dst []byte, s string) []byte {
+    return appendJSONStringStr(dst, s)
+}
+```
+
+- [ ] **Step 3.5: Update AppendAttr KindStr case and AppendField string case**
+
+In `AppendAttr`, `KindStr` case (around line 222):
+```go
+case model.KindStr:
+    dst = appendJSONStringStr(dst, attr.StrVal())
+```
+
+In `AppendField`, `string` case (around line 142):
+```go
+case string:
+    dst = appendJSONStringStr(dst, v)
+```
+
+- [ ] **Step 3.6: Run tests and bench**
+
+```bash
+go test -race ./config/
+go test -bench="BenchmarkAppendQuotedString_ASCII" -benchmem -count=5 ./config/
+```
+Expected: 0 allocs/op on ASCII bench; all tests pass.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add config/parse_field.go config/string_escape_bench_test.go
+git commit -m "perf(config): appendJSONStringStr eliminates []byte(s) alloc per string field
+
+Adds appendJSONStringStr that iterates over string directly. Updates
+AppendQuotedString, AppendAttr KindStr, AppendField string case.
+Saves ~20 ns + 2 allocs/event on hot path.
+
+refs #116"
+```
+
+---
+
+### Task 4: P6 — Pre-rendered level bytes
+
+**Files:**
+- Modify: `config/parse_field.go` (add `AppendQuotedLevel`)
+- Modify: `entry/entry.go` (call `AppendQuotedLevel`)
+- Create: `config/level_bytes_bench_test.go`
+
+- [ ] **Step 4.1: Write tests**
+
+```go
+// config/level_bytes_bench_test.go
+package config_test
+
+import (
+    "testing"
+    "github.com/architagr/lognugget/enum"
+)
+
+func Test_AppendQuotedLevel_AllNamedLevels(t *testing.T) {
+    cases := []struct {
+        level enum.LogLevel
+        want  string
+    }{
+        {enum.LevelDebug, `"DEBUG"`},
+        {enum.LevelInfo,  `"INFO"`},
+        {enum.LevelWarn,  `"WARN"`},
+        {enum.LevelError, `"ERROR"`},
+        {enum.LevelFatal, `"FATAL"`},
+    }
+    for _, c := range cases {
+        got := string(AppendQuotedLevel(nil, c.level))
+        if got != c.want {
+            t.Errorf("AppendQuotedLevel(%v) = %q, want %q", c.level, got, c.want)
+        }
+    }
+}
+
+func BenchmarkAppendQuotedLevel(b *testing.B) {
+    b.ReportAllocs()
+    dst := make([]byte, 0, 16)
+    b.ResetTimer()
+    for range b.N {
+        AppendQuotedLevel(dst[:0], enum.LevelInfo)
+    }
+}
+```
+
+- [ ] **Step 4.2: Add AppendQuotedLevel to parse_field.go**
+
+After `AppendQuotedString`:
+```go
+// AppendQuotedLevel appends the JSON-quoted string representation of l to dst.
+// For the 5 named levels it appends a pre-known literal (0 allocs, 0 function calls);
+// unknown levels fall back to AppendQuotedString(dst, l.String()).
+func AppendQuotedLevel(dst []byte, l enum.LogLevel) []byte {
+    switch l {
+    case enum.LevelDebug:
+        return append(dst, `"DEBUG"`...)
+    case enum.LevelInfo:
+        return append(dst, `"INFO"`...)
+    case enum.LevelWarn:
+        return append(dst, `"WARN"`...)
+    case enum.LevelError:
+        return append(dst, `"ERROR"`...)
+    case enum.LevelFatal:
+        return append(dst, `"FATAL"`...)
+    default:
+        return AppendQuotedString(dst, l.String())
+    }
+}
+```
+
+- [ ] **Step 4.3: Update entry.go — replace level encoding in logWithSkip**
+
+Find (around line 182):
+```go
+e.buf = config.AppendQuotedString(e.buf, level.String())
+```
+Replace with:
+```go
+e.buf = config.AppendQuotedLevel(e.buf, level)
+```
+
+- [ ] **Step 4.4: Run tests and bench**
+
+```bash
+go test -race ./config/ ./entry/
+go test -bench="BenchmarkAppendQuotedLevel" -benchmem -count=5 ./config/
+```
+Expected: 0 allocs/op; all tests pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add config/parse_field.go config/level_bytes_bench_test.go entry/entry.go
+git commit -m "perf(config,entry): AppendQuotedLevel eliminates level.String() alloc
+
+Adds AppendQuotedLevel with switch over 5 named levels appending
+pre-known quoted literals. Saves ~15 ns + 1 alloc/event.
+
+refs #117"
+```
+
+---
+
+### Task 5: P8 — Exact-size buffer alias severance
+
+**Files:**
+- Modify: `entry/entry.go` (1-line change in logWithSkip)
+- Create: `entry/buffer_size_bench_test.go`
+
+- [ ] **Step 5.1: Write benchmark**
+
+```go
+// entry/buffer_size_bench_test.go
+package entry_test
+
+import (
+    "context"
+    "runtime"
+    "testing"
+    "time"
+
+    "github.com/architagr/lognugget/config"
+    "github.com/architagr/lognugget/entry"
+    "github.com/architagr/lognugget/enum"
+    pipelineStage "github.com/architagr/lognugget/pipeline_stage"
+)
+
+type bufSizeWriter struct{}
+func (w *bufSizeWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func BenchmarkBufferSeverance_HotPath(b *testing.B) {
+    b.StopTimer()
+    prev := runtime.GOMAXPROCS(8)
+    b.Cleanup(func() { runtime.GOMAXPROCS(prev) })
+
+    config.SetMinLevel(enum.LevelDebug)
+    config.SetEncoderType(enum.EncoderJSON)
+    out := &bufSizeWriter{}
+    unset := pipelineStage.NewUnsetLogEventPostProcessor(2*time.Second, 1000, out)
+    pipelineStage.EventPreProcessorObj.RegisterHook(enum.LevelUnSet, unset)
+    config.InitPreProcessors(pipelineStage.EventPreProcessorObj)
+    entry.GenerateInitialPool(100_000)
+    b.Cleanup(unset.Stop)
+
+    ctx := context.Background()
+    b.ReportAllocs()
+    b.ResetTimer()
+    b.StartTimer()
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() {
+            entry.NewLogEntry().Info(ctx, "buffer size test message")
+        }
+    })
+}
+```
+
+- [ ] **Step 5.2: Run bench — capture B/op baseline (~1,411 B/op)**
+
+```bash
+go test -bench="BenchmarkBufferSeverance_HotPath" -benchmem -count=5 ./entry/
+```
+
+- [ ] **Step 5.3: Update alias severance in entry.go**
+
+Find (around line 240):
+```go
+e.buf = make([]byte, 0, initBufCap)
+```
+Replace with:
+```go
+newCap := len(data)
+if newCap < 64 {
+    newCap = 64
+}
+e.buf = make([]byte, 0, newCap)
+```
+
+- [ ] **Step 5.4: Run bench again — verify B/op drops**
+
+```bash
+go test -bench="BenchmarkBufferSeverance_HotPath" -benchmem -count=5 ./entry/
+go test -race ./entry/
+```
+Expected: B/op drops significantly (target ≤ 300 B/op); 0 allocs on filtered path.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add entry/entry.go entry/buffer_size_bench_test.go
+git commit -m "perf(entry): right-size alias severance buf to len(data) instead of 1024
+
+Reduces pool slot allocation from constant 1024 B to actual log line
+length. Pool naturally stabilises at typical line size (~200 B).
+Saves ~800 B/call.
+
+refs #119"
+```
+
+---
+
+## Batch 2 — After Batch 1 Merged (P2, P7)
+
+---
+
+### Task 6: P2 — atomic.Pointer[HotSnapshot]
+
+**Files:**
+- Modify: `config/config.go` (add `hotSnapshotPtr`, `storeHotSnapshot`, rewrite `GetHotSnapshot`, update 13+ mutators)
+- Create: `config/atomic_snapshot_v3_bench_test.go`
+
+- [ ] **Step 6.1: Write tests**
+
+```go
+// config/atomic_snapshot_v3_bench_test.go
+package config_test
+
+import (
+    "sync"
+    "testing"
+    "github.com/architagr/lognugget/enum"
+)
+
+func Test_GetHotSnapshot_NilSafe(t *testing.T) {
+    TestResetConfig()
+    snap := GetHotSnapshot()
+    if snap.Encoder == nil {
+        t.Fatal("snapshot encoder must not be nil after resetConfig")
+    }
+}
+
+func Test_HotSnapshot_ConsistentWithSetMinLevel(t *testing.T) {
+    TestResetConfig()
+    SetMinLevel(enum.LevelWarn)
+    // snapshot is rebuilt in SetMinLevel; atomic level must also be updated
+    if GetAtomicMinLevel() != enum.LevelWarn {
+        t.Fatal("atomicMinLevel not updated")
+    }
+}
+
+func Test_HotSnapshot_ConsistentWithSetTimeFormat(t *testing.T) {
+    TestResetConfig()
+    SetTimeFormat("2006-01-02")
+    snap := GetHotSnapshot()
+    if snap.TimeFormat != "2006-01-02" {
+        t.Fatalf("snapshot TimeFormat = %q, want %q", snap.TimeFormat, "2006-01-02")
+    }
+}
+
+func Test_HotSnapshot_RaceWithSetters(t *testing.T) {
+    t.Parallel()
+    TestResetConfig()
+    var wg sync.WaitGroup
+    for i := 0; i < 4; i++ {
+        wg.Add(2)
+        go func() {
+            defer wg.Done()
+            for j := 0; j < 500; j++ {
+                SetMinLevel(enum.LevelInfo)
+                SetTimeFormat("2006-01-02")
+            }
+        }()
+        go func() {
+            defer wg.Done()
+            for j := 0; j < 500; j++ {
+                _ = GetHotSnapshot()
+            }
+        }()
+    }
+    wg.Wait()
+}
+
+func BenchmarkGetHotSnapshot(b *testing.B) {
+    TestResetConfig()
+    b.ReportAllocs()
+    b.ResetTimer()
+    for range b.N {
+        _ = GetHotSnapshot()
+    }
+}
+```
+
+- [ ] **Step 6.2: Run tests to confirm they pass with current RLock-based implementation**
+
+```bash
+go test -race -run "Test_HotSnapshot_|Test_GetHotSnapshot_" ./config/
+go test -bench=BenchmarkGetHotSnapshot -benchmem -count=5 ./config/
+```
+Expected: tests pass; bench shows allocs > 0 (current impl allocates struct copy indirectly).
+
+- [ ] **Step 6.3: Add hotSnapshotPtr var and storeHotSnapshot helper**
+
+In `config/config.go`, after `var channelCapacity atomic.Int64`:
+```go
+// hotSnapshotPtr holds the current hot-path config snapshot. Writers update it
+// atomically under configMu.Lock() via storeHotSnapshot(); readers call
+// GetHotSnapshot() without any lock. The stored value is always non-nil after
+// the first resetConfig call (which runs at init).
+var hotSnapshotPtr atomic.Pointer[HotSnapshot]
+```
+
+Add `storeHotSnapshot()` just before `GetHotSnapshot`:
+```go
+// storeHotSnapshot builds a fresh HotSnapshot from current defaultConfig state
+// and atomically stores it. MUST be called while holding configMu (write lock).
+func storeHotSnapshot() {
+    snap := &HotSnapshot{
+        AddSource:        defaultConfig.addSource,
+        TimeFormat:       defaultConfig.timeFormat,
+        DefaultFields:    defaultConfig.defaultFields,
+        Rendered:         defaultConfig.defaultFieldsRendered,
+        StaticFields:     defaultConfig.parsedStaticFields,
+        ContextParser:    defaultConfig.contextParser,
+        ContextAppender:  defaultConfig.contextAppender,
+        Encoder:          defaultConfig.encoderObj,
+        EncoderType:      defaultConfig.encoderType,
+        RestrictedFields: restrictedFieldsSet,
+    }
+    snap.EncoderOpen  = snap.Encoder.OpenBytes()
+    snap.EncoderClose = snap.Encoder.CloseBytes()
+    hotSnapshotPtr.Store(snap)
+}
+```
+
+- [ ] **Step 6.4: Rewrite GetHotSnapshot**
+
+Replace the current `GetHotSnapshot` body:
+```go
+func GetHotSnapshot() HotSnapshot {
+    return *hotSnapshotPtr.Load()
+}
+```
+
+- [ ] **Step 6.5: Update resetConfig — call storeHotSnapshot before Unlock**
+
+At the end of `resetConfig`, just before `configMu.Unlock()`:
+```go
+storeHotSnapshot()
+```
+
+- [ ] **Step 6.6: Update all Set* mutators — call storeHotSnapshot at end**
+
+For each of the following functions, add `storeHotSnapshot()` as the last statement before `configMu.Unlock()` (or the `defer configMu.Unlock()` return):
+- `SetMinLevel`
+- `SetTimeFormat`
+- `SetEncoderType`
+- `SetAddSource`
+- `SetOutput`
+- `SetLogBufferMaxSize`
+- `SetRate`
+- `SetStaticEnvFieldsParser`
+- `SetContextFieldsParser`
+- `SetContextFieldsAppender`
+- `SetDefaultFields`
+- `RegisterHook`
+- `DeRegisterHook`
+
+Note: Functions that use `defer configMu.Unlock()` cannot call `storeHotSnapshot()` after the defer — they must either remove the defer and call manually, or add `storeHotSnapshot()` as the last non-deferred statement while still holding the lock.
+
+Pattern for defer-based functions:
+```go
+func SetTimeFormat(format string) {
+    configMu.Lock()
+    defaultConfig.timeFormat = format
+    storeHotSnapshot()
+    configMu.Unlock()
+}
+```
+
+- [ ] **Step 6.7: Run tests and bench**
+
+```bash
+go test -race -run "Test_HotSnapshot_|Test_GetHotSnapshot_" ./config/
+go test -race ./config/ ./entry/
+go test -bench=BenchmarkGetHotSnapshot -benchmem -count=5 ./config/
+```
+Expected: 0 allocs/op on BenchmarkGetHotSnapshot; all race tests pass.
+
+- [ ] **Step 6.8: Commit**
+
+```bash
+git add config/config.go config/atomic_snapshot_v3_bench_test.go
+git commit -m "perf(config): atomic.Pointer[HotSnapshot] eliminates GetHotSnapshot RLock
+
+Replaces configMu.RLock in GetHotSnapshot with atomic.Pointer load.
+All Set* mutators rebuild and atomically store a new snapshot under the
+existing write lock. Saves ~120 ns/event (biggest V3 win).
+
+refs #113"
+```
+
+---
+
+### Task 7: P7 — OTel ContextFieldsAppender + benchmarks
+
+**Files:**
+- Modify: `entry/parallel_bench_test.go`
+- Modify: `test/benchmark/log_parallel_bench_test.go`
+- Create: `test/benchmark/otel_bench_test.go`
+- Create: `examples/otel-appender/main.go`
+- Create: `examples/otel-appender/go.mod`
+
+- [ ] **Step 7.1: Update BenchmarkLognugget_Parallel_10CtxFields in entry/parallel_bench_test.go**
+
+Replace `config.SetContextFieldsParser(...)` block with:
+```go
+config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+    return append(dst,
+        `,"k1":"v1","k2":"v2","k3":"v3","k4":"v4","k5":"v5",`+
+        `"k6":"v6","k7":"v7","k8":"v8","k9":"v9","k10":"v10"`...)
+})
+```
+
+- [ ] **Step 7.2: Update Benchmark_Log_Parallel_10CtxFields in test/benchmark/log_parallel_bench_test.go**
+
+Replace `config.SetContextFieldsParser(...)` block with:
+```go
+config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+    return append(dst,
+        `,"trace_id":"abc123def456","span_id":"span789",`+
+        `"request_id":"req-001","user_id":"usr-42","session_id":"sess-x",`+
+        `"region":"us-east-1","service":"api-gateway","version":"1.2.3",`+
+        `"env":"production","pod":"pod-abc"`...)
+})
+```
+
+- [ ] **Step 7.3: Create OTel benchmark (build-tag isolated)**
+
+```go
+// test/benchmark/otel_bench_test.go
+//go:build otel_bench
+
+package benchmark
+
+import (
+    "context"
+    "testing"
+    "time"
+
+    "github.com/architagr/lognugget/config"
+    "github.com/architagr/lognugget/entry"
+    "github.com/architagr/lognugget/enum"
+    pipelineStage "github.com/architagr/lognugget/pipeline_stage"
+    "go.opentelemetry.io/otel/trace"
+)
+
+// Benchmark_Log_Parallel_OtelCtx demonstrates the OTel ContextFieldsAppender pattern.
+// Run with: go test -tags otel_bench -bench=Benchmark_Log_Parallel_OtelCtx ./test/benchmark/
+func Benchmark_Log_Parallel_OtelCtx(b *testing.B) {
+    out := &MockWriter{}
+    config.SetMinLevel(enum.LevelDebug)
+    config.SetEncoderType(enum.EncoderJSON)
+    config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+        span := trace.SpanFromContext(ctx)
+        if !span.IsRecording() {
+            return dst
+        }
+        sc := span.SpanContext()
+        dst = append(dst, `,"trace_id":"`...)
+        dst = append(dst, sc.TraceID().String()...)
+        dst = append(dst, `","span_id":"`...)
+        dst = append(dst, sc.SpanID().String()...)
+        dst = append(dst, '"')
+        return dst
+    })
+
+    proc := pipelineStage.NewUnsetLogEventPostProcessor(2*time.Second, 500, out)
+    defer proc.Stop()
+    pipelineStage.EventPreProcessorObj.RegisterHook(enum.LevelUnSet, proc)
+    config.InitPreProcessors(pipelineStage.EventPreProcessorObj)
+    entry.GenerateInitialPool(1_000_000)
+
+    ctx := context.Background()
+    b.ReportAllocs()
+    b.ResetTimer()
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() {
+            entry.NewLogEntry().Info(ctx, "otel ctx bench")
+        }
+    })
+}
+```
+
+- [ ] **Step 7.4: Create examples/otel-appender/**
+
+```go
+// examples/otel-appender/main.go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+
+    "github.com/architagr/lognugget/config"
+    "github.com/architagr/lognugget/entry"
+    "github.com/architagr/lognugget/enum"
+    pipelineStage "github.com/architagr/lognugget/pipeline_stage"
+    "go.opentelemetry.io/otel/trace"
+    "time"
+)
+
+func init() {
+    config.SetOutput(os.Stdout)
+    config.SetMinLevel(enum.LevelDebug)
+
+    // Zero-alloc OTel context appender: extracts trace/span IDs from the
+    // active OTel span and appends them as JSON fields directly into the
+    // log-line buffer — no map allocation, no intermediate string.
+    config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+        span := trace.SpanFromContext(ctx)
+        if !span.IsRecording() {
+            return dst
+        }
+        sc := span.SpanContext()
+        dst = append(dst, `,"trace_id":"`...)
+        dst = append(dst, sc.TraceID().String()...)
+        dst = append(dst, `","span_id":"`...)
+        dst = append(dst, sc.SpanID().String()...)
+        dst = append(dst, '"')
+        return dst
+    })
+
+    unset := pipelineStage.NewUnsetLogEventPostProcessor(5*time.Second, 100, config.GetConfig().Output())
+    pipelineStage.EventPreProcessorObj.RegisterHook(enum.LevelUnSet, unset)
+    config.InitPreProcessors(pipelineStage.EventPreProcessorObj)
+}
+
+func main() {
+    ctx := context.Background()
+    entry.NewLogEntry().Info(ctx, "OTel appender example — no active span, no trace fields")
+
+    // With an active OTel span, trace_id and span_id are appended automatically.
+    fmt.Println("See examples/gin-demo/ for HTTP handler integration.")
+}
+```
+
+- [ ] **Step 7.5: Create examples/otel-appender/go.mod**
+
+```
+module github.com/architagr/lognugget/examples/otel-appender
+
+go 1.21
+
+require (
+    github.com/architagr/lognugget v0.0.0
+    go.opentelemetry.io/otel v1.24.0
+    go.opentelemetry.io/otel/trace v1.24.0
+)
+
+replace github.com/architagr/lognugget => ../../
+```
+
+- [ ] **Step 7.6: Run bench — verify ≤ 1 alloc**
+
+```bash
+go test -bench="BenchmarkLognugget_Parallel_10CtxFields" -benchmem -count=5 ./entry/
+go test -bench="Benchmark_Log_Parallel_10CtxFields" -benchmem -count=5 ./test/benchmark/
+```
+Expected: ≤ 1 alloc/op (down from 7 in V2 with map parser).
+
+- [ ] **Step 7.7: Verify otel-appender example compiles**
+
+```bash
+cd examples/otel-appender && go mod tidy && go build ./... && cd -
+```
+
+- [ ] **Step 7.8: Commit**
+
+```bash
+git add entry/parallel_bench_test.go test/benchmark/log_parallel_bench_test.go
+git add test/benchmark/otel_bench_test.go
+git add examples/otel-appender/
+git commit -m "feat(bench,examples): switch 10ctx benchmarks to ContextFieldsAppender, add OTel example
+
+Updates Benchmark_Log_Parallel_10CtxFields to use SetContextFieldsAppender
+(zero-alloc). Adds Benchmark_Log_Parallel_OtelCtx (build tag otel_bench)
+and examples/otel-appender/ showing OTel trace/span extraction pattern.
+Saves ~100 ns + 4 allocs/event vs legacy map parser.
+
+refs #118"
+```
+
+---
+
+## Batch 3 — After P2 Merged (P3)
+
+---
+
+### Task 8: P3 — Atomic channel pointer
+
+**Files:**
+- Modify: `config/config.go` (add `atomicCh`, update `resetConfig`, rewrite `PublishLog`)
+- Create: `config/atomic_channel_bench_test.go`
+
+- [ ] **Step 8.1: Write tests**
+
+```go
+// config/atomic_channel_bench_test.go
+package config_test
+
+import (
+    "sync"
+    "testing"
+    "github.com/architagr/lognugget/enum"
+)
+
+func Test_PublishLog_Race(t *testing.T) {
+    t.Parallel()
+    TestResetConfig()
+    proc := newTestProcessor()
+    InitPreProcessors(proc)
+    var wg sync.WaitGroup
+    for i := 0; i < 8; i++ {
+        wg.Add(1)
+        go func() {
+            defer wg.Done()
+            for j := 0; j < 100; j++ {
+                PublishLog(enum.LevelInfo, []byte(`{"test":true}`))
+            }
+        }()
+    }
+    wg.Wait()
+}
+
+func BenchmarkPublishLog(b *testing.B) {
+    TestResetConfig()
+    proc := newTestProcessor()
+    InitPreProcessors(proc)
+    data := []byte(`{"level":"INFO","message":"bench"}`)
+    b.ReportAllocs()
+    b.ResetTimer()
+    for range b.N {
+        PublishLog(enum.LevelInfo, data)
+    }
+}
+```
+
+- [ ] **Step 8.2: Add atomicCh var**
+
+In `config/config.go`, after `var channelCapacity atomic.Int64`:
+```go
+// atomicCh holds the current dispatch channel as an atomic.Value so
+// PublishLog can load it without acquiring configMu. Updated by resetConfig
+// under configMu.Lock() immediately after ch is assigned.
+var atomicCh atomic.Value // stores chan LogEvent
+```
+
+- [ ] **Step 8.3: Update resetConfig — store into atomicCh**
+
+After `ch = newCh` (inside `configMu.Lock()`):
+```go
+atomicCh.Store(newCh)
+```
+
+- [ ] **Step 8.4: Rewrite PublishLog**
+
+Replace the current body:
+```go
+func PublishLog(Level enum.LogLevel, Data []byte) {
+    atomicCh.Load().(chan LogEvent) <- LogEvent{
+        Level: Level,
+        Data:  Data,
+    }
+}
+```
+
+- [ ] **Step 8.5: Run tests and bench**
+
+```bash
+go test -race -run "Test_PublishLog_Race" ./config/
+go test -bench=BenchmarkPublishLog -benchmem -count=5 ./config/
+go test -race ./...
+```
+Expected: no races; tests pass.
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add config/config.go config/atomic_channel_bench_test.go
+git commit -m "perf(config): atomic.Value channel pointer eliminates PublishLog RLock
+
+Replaces configMu.RLock in PublishLog with atomic.Value load. Together
+with P1+P2, the hot path now has zero configMu.RLock acquisitions.
+Saves ~50 ns/event.
+
+refs #114"
+```
+
+---
+
+## Batch 4 — Final (P9)
+
+---
+
+### Task 9: P9 — Lock-free MPSC ring buffer
+
+**Files:**
+- Create: `config/ring_buffer.go`
+- Create: `config/ring_buffer_test.go`
+- Create: `config/ring_buffer_bench_test.go`
+- Modify: `config/config.go` (replace `ch chan LogEvent` with `ring *mpscRingBuffer`, update `resetConfig`, `PublishLog`, `ProcessLogEvent`)
+
+- [ ] **Step 9.1: Create ring_buffer.go**
+
+```go
+// config/ring_buffer.go
+package config
+
+import "runtime"
+
+const (
+    ringSize = 4096
+    ringMask = uint64(ringSize - 1)
+)
+
+type ringSlot struct {
+    seq  atomicUint64
+    data LogEvent
+    _    [40]byte // pad to 64 bytes (1 cache line): seq(8)+data(16)+pad(40)
+}
+
+type mpscRingBuffer struct {
+    _     [64]byte    // isolate from preceding allocator metadata
+    tail  atomicUint64 // producers: fetch-and-add
+    _     [56]byte    // pad tail to its own cache line
+    head  atomicUint64 // consumer: load/store (single goroutine)
+    _     [56]byte    // pad head to its own cache line
+    slots [ringSize]ringSlot
+}
+
+// Use sync/atomic Uint64 wrapper type alias for readability.
+// In Go 1.19+ atomic.Uint64 is a struct with Load/Store/Add methods.
+type atomicUint64 = atomic.Uint64
+
+func newMpscRingBuffer() *mpscRingBuffer {
+    r := new(mpscRingBuffer)
+    for i := uint64(0); i < ringSize; i++ {
+        r.slots[i].seq.Store(i)
+    }
+    return r
+}
+
+// Push enqueues e. If all slots are in use, spins with runtime.Gosched
+// until one is freed by the consumer. Safe for concurrent use by multiple
+// producers.
+func (r *mpscRingBuffer) Push(e LogEvent) {
+    pos := r.tail.Add(1) - 1
+    slot := &r.slots[pos&ringMask]
+    for slot.seq.Load() != pos {
+        runtime.Gosched()
+    }
+    slot.data = e
+    slot.seq.Store(pos + 1)
+}
+
+// Pop dequeues the next event. Returns (LogEvent{}, false) if the ring is
+// empty. Must be called from exactly one goroutine (the consumer).
+func (r *mpscRingBuffer) Pop() (LogEvent, bool) {
+    pos := r.head.Load()
+    slot := &r.slots[pos&ringMask]
+    if slot.seq.Load() != pos+1 {
+        return LogEvent{}, false
+    }
+    e := slot.data
+    slot.seq.Store(pos + ringSize)
+    r.head.Store(pos + 1)
+    return e, true
+}
+
+// Len returns an approximate item count (not precise under concurrent producers).
+func (r *mpscRingBuffer) Len() int {
+    tail := r.tail.Load()
+    head := r.head.Load()
+    if tail <= head {
+        return 0
+    }
+    if n := tail - head; n < ringSize {
+        return int(n)
+    }
+    return ringSize
+}
+```
+
+Note: `atomic.Uint64` requires `import "sync/atomic"` — add to imports.
+
+- [ ] **Step 9.2: Write ring buffer tests**
+
+```go
+// config/ring_buffer_test.go
+package config
+
+import (
+    "sync"
+    "testing"
+    "github.com/architagr/lognugget/enum"
+)
+
+func Test_RingBuffer_PushPop_Sequential(t *testing.T) {
+    r := newMpscRingBuffer()
+    events := make([]LogEvent, 100)
+    for i := range events {
+        events[i] = LogEvent{Level: enum.LevelInfo, Data: []byte{byte(i)}}
+        r.Push(events[i])
+    }
+    for i := range events {
+        e, ok := r.Pop()
+        if !ok {
+            t.Fatalf("Pop %d: expected event, got empty", i)
+        }
+        if e.Data[0] != byte(i) {
+            t.Fatalf("Pop %d: got data %d, want %d", i, e.Data[0], i)
+        }
+    }
+    if _, ok := r.Pop(); ok {
+        t.Fatal("expected empty ring after draining all events")
+    }
+}
+
+func Test_RingBuffer_Empty(t *testing.T) {
+    r := newMpscRingBuffer()
+    if _, ok := r.Pop(); ok {
+        t.Fatal("Pop on empty ring must return false")
+    }
+}
+
+func Test_RingBuffer_MPSC_Race(t *testing.T) {
+    t.Parallel()
+    const producers = 8
+    const eventsPerProducer = 1000
+    r := newMpscRingBuffer()
+
+    var wg sync.WaitGroup
+    for i := 0; i < producers; i++ {
+        wg.Add(1)
+        go func(id int) {
+            defer wg.Done()
+            for j := 0; j < eventsPerProducer; j++ {
+                r.Push(LogEvent{Level: enum.LevelInfo, Data: []byte{byte(id)}})
+            }
+        }(i)
+    }
+
+    received := make(chan struct{}, producers*eventsPerProducer)
+    done := make(chan struct{})
+    go func() {
+        for {
+            select {
+            case <-done:
+                for r.Len() > 0 {
+                    if _, ok := r.Pop(); ok {
+                        received <- struct{}{}
+                    }
+                }
+                close(received)
+                return
+            default:
+                if _, ok := r.Pop(); ok {
+                    received <- struct{}{}
+                }
+            }
+        }
+    }()
+
+    wg.Wait()
+    close(done)
+
+    count := 0
+    for range received {
+        count++
+    }
+    if count != producers*eventsPerProducer {
+        t.Fatalf("got %d events, want %d", count, producers*eventsPerProducer)
+    }
+}
+```
+
+- [ ] **Step 9.3: Run ring buffer tests under -race**
+
+```bash
+go test -race -run "Test_RingBuffer_" -v ./config/
+```
+Expected: all pass, no races.
+
+- [ ] **Step 9.4: Write ring buffer benchmark**
+
+```go
+// config/ring_buffer_bench_test.go
+package config
+
+import (
+    "runtime"
+    "testing"
+    "github.com/architagr/lognugget/enum"
+)
+
+func BenchmarkRingBuffer_Push(b *testing.B) {
+    prev := runtime.GOMAXPROCS(8)
+    b.Cleanup(func() { runtime.GOMAXPROCS(prev) })
+    r := newMpscRingBuffer()
+    // consumer goroutine
+    go func() {
+        for range b.N + 1 {
+            for {
+                if _, ok := r.Pop(); ok {
+                    break
+                }
+                runtime.Gosched()
+            }
+        }
+    }()
+    e := LogEvent{Level: enum.LevelInfo, Data: []byte(`{"test":true}`)}
+    b.ReportAllocs()
+    b.ResetTimer()
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() {
+            r.Push(e)
+        }
+    })
+}
+```
+
+- [ ] **Step 9.5: Replace chan LogEvent with ring in config.go**
+
+1. Add `import "sync/atomic"` if not present (needed for `atomic.Uint64` in ring_buffer.go).
+2. Replace `ch chan LogEvent` global with `ring *mpscRingBuffer`.
+3. Update `resetConfig`:
+   - Remove `newCh := make(chan LogEvent, ...)` and `ch = newCh`
+   - Add `ring = newMpscRingBuffer()`
+   - Remove `atomicCh.Store(newCh)` (P3 — keep `atomicCh` but don't need it anymore; or adapt to store ring)
+4. Rewrite `PublishLog`:
+   ```go
+   func PublishLog(Level enum.LogLevel, Data []byte) {
+       ring.Push(LogEvent{Level: Level, Data: Data})
+   }
+   ```
+5. Rewrite `ProcessLogEvent`:
+   ```go
+   func ProcessLogEvent() {
+       for {
+           e, ok := ring.Pop()
+           if !ok {
+               runtime.Gosched()
+               continue
+           }
+           configMu.RLock()
+           processors := EventPreProcessors
+           configMu.RUnlock()
+           for _, p := range processors {
+               p.PreProcess(e.Level, e.Data)
+           }
+       }
+   }
+   ```
+   Note: the stop/drain coordination (`doneCh`, `flushWg`) must be updated — see story-P9 for the sentinel-event pattern.
+
+- [ ] **Step 9.6: Run full test suite including integration**
+
+```bash
+go test -race ./...
+```
+Expected: all green including integration stop/drain tests.
+
+- [ ] **Step 9.7: Run parallel benchmark — verify ≤ 500 ns/op**
+
+```bash
+go test -bench="Benchmark_Log_Parallel_NoCtx" -benchmem -count=10 ./entry/ ./test/benchmark/
+./scripts/bench-check.sh
+```
+Expected: ≤ 500 ns/op; bench-check exits 0.
+
+- [ ] **Step 9.8: Commit**
+
+```bash
+git add config/ring_buffer.go config/ring_buffer_test.go config/ring_buffer_bench_test.go config/config.go
+git commit -m "perf(config): lock-free MPSC ring buffer replaces chan LogEvent dispatch
+
+Eliminates ~130 ns/call channel mutex overhead under 8-goroutine
+contention. Achieves ≤ 500 ns/op V3 target on parallel hot path.
+Ring size 4096 provides 4× headroom vs channel cap of 1000.
+
+refs #120"
+```
+
+---
+
+## Task 10: Feature Branch Merge Gate
+
+- [ ] **Step 10.1: Run bench-check on full feature branch**
+
+```bash
+./scripts/bench-check.sh
+```
+Expected: exits 0; all benchmarks ≤ 1,000 ns/op (gate threshold).
+
+- [ ] **Step 10.2: Run full race suite**
+
+```bash
+go test -race -count=3 ./...
+```
+
+- [ ] **Step 10.3: Run lint**
+
+```bash
+golangci-lint run
+```
+
+- [ ] **Step 10.4: Project Lead updates baseline**
+
+```bash
+./scripts/bench-check.sh --update-baseline
+git add bench-baseline.txt
+git commit -m "chore: update bench-baseline.txt for V3 (P1-P9 combined)
+
+All parallel benchmarks ≤ 500 ns/op. Closes Epic V3 goal.
+refs #111"
+```
+
+- [ ] **Step 10.5: Open PR feat/111-v3-performance → develop**
+
+```bash
+./.claude/scripts/github-api.sh mark-pr-ready <pr-number>
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- ✅ P1 (F1, F2): atomic.Bool gate — Task 1
+- ✅ P2 (F3, F4): atomic.Pointer snapshot — Task 6
+- ✅ P3 (F5, F6): atomic channel — Task 8
+- ✅ P4 (F7): direct timestamp — Task 2
+- ✅ P5 (F8, F9): string-native escape — Task 3
+- ✅ P6 (F10, F11): level bytes — Task 4
+- ✅ P7 (F12, F13, F14): OTel appender + examples — Task 7
+- ✅ P8 (F15): buffer size — Task 5
+- ✅ P9 (F16): ring buffer — Task 9
+- ✅ F17: all stories have bench_test.go with `b.ReportAllocs()`
+- ✅ F18: Task 10 runs bench-check.sh
+
+**Placeholder scan:** None found.
+
+**Type consistency:**
+- `hasPreProcessorsAtomic` (Task 1) — `atomic.Bool` throughout
+- `hotSnapshotPtr` (Task 6) — `atomic.Pointer[HotSnapshot]` throughout
+- `atomicCh` (Task 8) — `atomic.Value` storing `chan LogEvent`; P9 replaces the channel entirely
+- `mpscRingBuffer.Push/Pop` (Task 9) — `LogEvent` throughout; matches `config.LogEvent` struct

--- a/docs/wiki/v3-performance.md
+++ b/docs/wiki/v3-performance.md
@@ -1,0 +1,356 @@
+# Epic V3 — Sub-500 ns Hot Path + First-Class OTel Distributed Tracing
+
+Status: IN PROGRESS (2026-05-22)
+Owner: Project Lead
+Umbrella issue: [#111](https://github.com/architagr/LogNugget/issues/111)
+Sources of truth: `docs/STATUS.md`, `docs/prds/v3-performance.md`, `config/config.go`, `entry/entry.go`, `config/parse_field.go`
+
+---
+
+## 1. Problem Statement
+
+LogNugget V2 achieves ~1,090 ns/op on the parallel no-context hot path and ~1,280 ns/op with 10 context fields, with 5–7 allocs/op. This is a major improvement over V1 (~3,440 ns/op, 55 allocs), but still 10× slower than zerolog on raw ns/op.
+
+The V3 goal is ≤ 500 ns/op / ≤ 1 alloc on the parallel hot path — cutting the remaining gap in half — while adding first-class OpenTelemetry distributed tracing support.
+
+### V2 vs V3 targets
+
+| Metric | zerolog | V2 baseline | V3 target |
+|--------|---------|-------------|-----------|
+| ns/op (parallel NoCtx) | ~110 | ~1,090 | ≤ 500 |
+| ns/op (parallel 10ctx appender) | ~110 | ~1,280 | ≤ 500 |
+| allocs/op (parallel NoCtx) | 0 | 5 | ≤ 1 |
+| B/op (parallel hot path) | 0 | ~1,411 | ≤ 300 |
+
+### Remaining bottlenecks (post-V2 analysis)
+
+| # | Bottleneck | Location | Est. saving |
+|---|-----------|----------|-------------|
+| P1 | `HasEventPreProcessors()` acquires `configMu.RLock` every call | `config/config.go:273` | ~80 ns |
+| P2 | `GetHotSnapshot()` acquires `configMu.RLock` + copies 13-field struct | `config/config.go:153` | ~120 ns |
+| P3 | `PublishLog()` acquires `configMu.RLock` for channel pointer | `config/config.go:358` | ~50 ns |
+| P4 | `customTime.Format()` returns string; `AppendQuotedString` converts back to `[]byte` | `entry/entry.go:179` | ~40 ns, 2 allocs |
+| P5 | `AppendQuotedString` calls `[]byte(s)` on every string field | `config/parse_field.go:26` | ~20 ns, 2 allocs |
+| P6 | `level.String()` + `AppendQuotedString` — 5 known-constant values | `entry/entry.go:182` | ~15 ns, 1 alloc |
+| P7 | No built-in OTel; benchmark uses legacy map parser | `test/benchmark/` | ~100 ns, 4 allocs |
+| P8 | Alias severance allocates 1024 B regardless of actual line size (~200 B) | `entry/entry.go:240` | ~800 B/call |
+| P9 | Go channel contention under 8-goroutine load ~130 ns | `config/config.go:362` | ~130 ns |
+
+Total theoretical saving: ~555 ns + 9 allocs + 1100 B/call. Achieves ≤ 500 ns/op target.
+
+---
+
+## 2. Goals
+
+- G1. Achieve `Benchmark_Log_Parallel_NoCtx` ≤ 500 ns/op (GOMAXPROCS=8).
+- G2. Achieve `Benchmark_Log_Parallel_10CtxFields` (OTel appender) ≤ 500 ns/op, ≤ 1 alloc/op.
+- G3. Eliminate every `configMu.RLock` from the hot path (P1, P2, P3).
+- G4. Eliminate every string→[]byte and []byte→string conversion on the hot path (P4, P5, P6).
+- G5. Provide a first-class OTel tracing integration example and benchmark (P7).
+- G6. Right-size the per-call pool buffer allocation (P8).
+- G7. Replace channel dispatch with a lock-free MPSC ring buffer (P9).
+- G8. Preserve full backward compatibility: all V2 public APIs unchanged.
+
+## 3. Non-Goals
+
+- N1. Closing the full gap to zerolog (zerolog's 0 alloc advantage comes from sync write; LogNugget's async model is a structural trade-off).
+- N2. Bundling OTel SDK in the core module.
+- N3. New encoder formats.
+- N4. New log levels.
+- N5. Raising the bench-check gate threshold.
+
+---
+
+## 4. Actors
+
+| Actor | Role |
+|---|---|
+| HTTP handler goroutines | Producers: call `entry.NewLogEntry().Info(ctx, msg)` |
+| Background ProcessLogEvent goroutine | Consumer: drains ring buffer (post-P9) |
+| Pre-processors (hooks) | Route events to registered hooks |
+| OTel SDK (user-provided) | Populates span context; extracted by `ContextFieldsAppender` |
+
+---
+
+## 5. Architecture — V3 Hot Path
+
+### V2 hot path (3 RLocks remaining)
+
+```
+NewLogEntry()                           // pool get — 0 allocs (warm)
+  → atomic.Int64.Load(minLevel)         // P1 gate — 0 locks ✅ (V2)
+  → configMu.RLock (HasPreProcessors)   // ⚠️ RLock #1 — P1 target
+  → configMu.RLock (GetHotSnapshot)     // ⚠️ RLock #2 — P2 target
+  → []byte(timeStr) in AppendQuotedString  // ⚠️ alloc — P4/P5 target
+  → level.String() + []byte(levelStr)   // ⚠️ alloc — P6 target
+  → context fields via map parser       // ⚠️ +4 allocs — P7 target
+  → configMu.RLock (PublishLog ch)      // ⚠️ RLock #3 — P3 target
+  → ch <- LogEvent{...}                 // ⚠️ channel contention — P9 target
+  → make([]byte, 0, 1024)               // ⚠️ 1024B alloc — P8 target
+```
+
+### V3 hot path (0 RLocks, 0 allocs target)
+
+```
+NewLogEntry()                           // pool get — 0 allocs (warm)
+  → atomic.Int64.Load(minLevel)         // 0 locks ✅
+  → atomic.Bool.Load(hasPreProcessors)  // ✅ P1 — 0 locks
+  → hotSnapshotPtr.Load()               // ✅ P2 — 0 locks, returns *HotSnapshot
+  → append(buf, '"'); t.AppendFormat(); append('"')  // ✅ P4 — 0 allocs
+  → appendJSONStringStr(buf, level)     // ✅ P5+P6 — 0 allocs
+  → contextAppender(ctx, buf)           // ✅ P7 — 0 allocs (appender path)
+  → atomicCh.Load().(chan LogEvent) <-  // ✅ P3 — no RLock before send
+    ... or ring.Push(event)             // ✅ P9 — lock-free MPSC
+  → make([]byte, 0, len(data))          // ✅ P8 — right-sized
+```
+
+---
+
+## 6. Design Details by Story
+
+### P1 — atomic.Bool pre-processor gate
+
+**Current:** `HasEventPreProcessors()` at `config/config.go:273` acquires `configMu.RLock()`, reads `len(EventPreProcessors)`, releases the lock. Called once per log event on the hot path.
+
+**Change:**
+```go
+// New package-level atomic
+var hasPreProcessorsAtomic atomic.Bool
+
+// HasEventPreProcessors — lock-free read
+func HasEventPreProcessors() bool { return hasPreProcessorsAtomic.Load() }
+
+// Updated mutators (under configMu.Lock):
+// InitPreProcessors: hasPreProcessorsAtomic.Store(len(observers) > 0)
+// AddPreProcessors:  hasPreProcessorsAtomic.Store(true)
+// RemovePreProcessor: hasPreProcessorsAtomic.Store(len(EventPreProcessors) > 0)
+```
+
+**Files:** `config/config.go` (add var, update 3 mutators, rewrite `HasEventPreProcessors`).
+New test file: `config/atomic_preprocessor_bench_test.go`.
+
+### P2 — atomic.Pointer[HotSnapshot] copy-on-write
+
+**Current:** `GetHotSnapshot()` at `config/config.go:153` acquires `configMu.RLock()`, copies a 13-field struct, releases lock, then calls `Encoder.OpenBytes()` / `CloseBytes()`.
+
+**Change:**
+```go
+// New package-level atomic
+var hotSnapshotPtr atomic.Pointer[HotSnapshot]
+
+// GetHotSnapshot — lock-free read
+func GetHotSnapshot() HotSnapshot { return *hotSnapshotPtr.Load() }
+
+// New helper called by all Set* mutators and resetConfig (under Lock):
+func storeHotSnapshot() {
+    snap := HotSnapshot{
+        AddSource:       defaultConfig.addSource,
+        TimeFormat:      defaultConfig.timeFormat,
+        // ... all 13 fields
+    }
+    snap.EncoderOpen  = snap.Encoder.OpenBytes()
+    snap.EncoderClose = snap.Encoder.CloseBytes()
+    hotSnapshotPtr.Store(&snap)
+}
+```
+
+**Files:** `config/config.go` — add var, add `storeHotSnapshot()`, update `resetConfig` + all `Set*` mutators (10 functions).
+New test file: `config/atomic_snapshot_v3_bench_test.go`.
+
+### P3 — atomic channel pointer
+
+**Current:** `PublishLog()` acquires `configMu.RLock()` to snapshot `ch`, releases lock, then sends.
+
+**Change:**
+```go
+var atomicCh atomic.Value  // stores chan LogEvent
+
+func PublishLog(Level enum.LogLevel, Data []byte) {
+    atomicCh.Load().(chan LogEvent) <- LogEvent{Level: Level, Data: Data}
+}
+
+// In resetConfig (under Lock):
+ch = newCh
+atomicCh.Store(newCh)
+```
+
+**Files:** `config/config.go` — add var, update `resetConfig`, rewrite `PublishLog`.
+
+### P4 — direct timestamp append
+
+**Current:** `entry/entry.go:179`:
+```go
+e.buf = config.AppendQuotedString(e.buf, customTime.Format(customTime.TimeNow(), snap.TimeFormat))
+```
+`customTime.Format` returns a string (1 alloc); `AppendQuotedString` calls `[]byte(s)` (1 alloc).
+
+**Change:**
+```go
+now := customTime.TimeNow()
+e.buf = append(e.buf, '"')
+e.buf = now.AppendFormat(e.buf, snap.TimeFormat)
+e.buf = append(e.buf, '"')
+```
+Zero allocations. RFC3339 output contains no JSON-unsafe characters.
+
+**Files:** `entry/entry.go` (3-line change at logWithSkip timestamp section).
+
+### P5 — string-native JSON escape
+
+**Current:** `config/parse_field.go:26`:
+```go
+func AppendQuotedString(dst []byte, s string) []byte {
+    return appendJSONString(dst, []byte(s))  // []byte(s) = alloc
+}
+```
+
+**Change:** Add `appendJSONStringStr(dst []byte, s string) []byte` that iterates over `s` as a string (no conversion). Update `AppendQuotedString`, `AppendAttr` (KindStr), and `AppendField` (string case) to use it.
+
+**Files:** `config/parse_field.go`.
+
+### P6 — pre-rendered level bytes
+
+**Current:** `entry/entry.go:182`:
+```go
+e.buf = config.AppendQuotedString(e.buf, level.String())
+```
+`level.String()` calls `fmt.Sprintf` (1 alloc for non-named levels; 0 for named but still produces a string).
+
+**Change:** Add to `config/parse_field.go`:
+```go
+func AppendQuotedLevel(dst []byte, l enum.LogLevel) []byte {
+    switch l {
+    case enum.LevelDebug: return append(dst, `"DEBUG"`...)
+    case enum.LevelInfo:  return append(dst, `"INFO"`...)
+    case enum.LevelWarn:  return append(dst, `"WARN"`...)
+    case enum.LevelError: return append(dst, `"ERROR"`...)
+    case enum.LevelFatal: return append(dst, `"FATAL"`...)
+    default: return AppendQuotedString(dst, l.String())
+    }
+}
+```
+Then in `entry.go`: `e.buf = config.AppendQuotedLevel(e.buf, level)`.
+
+**Files:** `config/parse_field.go` (new function), `entry/entry.go` (1-line change).
+
+### P7 — first-class OTel ContextFieldsAppender
+
+**Current:** `Benchmark_Log_Parallel_10CtxFields` uses `config.SetContextFieldsParser` (map-based, ~100 ns, 4 allocs). No OTel example exists.
+
+**Change:**
+1. Update both `Benchmark_Log_Parallel_10CtxFields` benches to use `SetContextFieldsAppender`.
+2. Add `Benchmark_Log_Parallel_OtelCtx` showing OTel span extraction.
+3. Create `examples/otel-appender/main.go` demonstrating the pattern.
+
+**Example OTel appender pattern:**
+```go
+config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+    span := trace.SpanFromContext(ctx)
+    if !span.IsRecording() {
+        return dst
+    }
+    sc := span.SpanContext()
+    dst = append(dst, `,"trace_id":"`...)
+    dst = append(dst, sc.TraceID().String()...)
+    dst = append(dst, `","span_id":"`...)
+    dst = append(dst, sc.SpanID().String()...)
+    dst = append(dst, '"')
+    return dst
+})
+```
+
+**Files:** `entry/parallel_bench_test.go`, `test/benchmark/log_parallel_bench_test.go`, new `test/benchmark/otel_bench_test.go`, new `examples/otel-appender/`.
+
+### P8 — exact-size buffer alias severance
+
+**Current:** `entry/entry.go:240`:
+```go
+e.buf = make([]byte, 0, initBufCap)  // always 1024 B
+```
+
+**Change:**
+```go
+e.buf = make([]byte, 0, len(data))   // right-sized to actual log line
+```
+
+Over time the pool slots naturally grow to hold actual line sizes; first reuse of a larger line causes one realloc, then stabilises.
+
+**Files:** `entry/entry.go` (1-line change).
+
+### P9 — lock-free MPSC ring buffer
+
+**Current:** `chan LogEvent` with capacity 1000. Channel send costs ~130 ns under 8-goroutine contention (internal mutex).
+
+**Change:** Replace with a lock-free MPSC ring buffer in `config/ring_buffer.go`:
+
+```go
+const (
+    ringSize = 4096       // power of 2; must be > realistic burst
+    ringMask = ringSize - 1
+)
+
+type ringSlot struct {
+    seq  atomic.Uint64
+    data LogEvent
+    _    [40]byte  // pad to 64-byte cache line
+}
+
+type mpscRingBuffer struct {
+    _     [64]byte       // padding
+    tail  atomic.Uint64  // producers fetch-and-add
+    _     [56]byte
+    head  atomic.Uint64  // consumer reads
+    _     [56]byte
+    slots [ringSize]ringSlot
+}
+```
+
+**Producer (Push — called by many goroutines):**
+```go
+func (r *mpscRingBuffer) Push(e LogEvent) {
+    pos := r.tail.Add(1) - 1
+    slot := &r.slots[pos&ringMask]
+    for slot.seq.Load() != pos { runtime.Gosched() }
+    slot.data = e
+    slot.seq.Store(pos + 1)
+}
+```
+
+**Consumer (Pop — single goroutine only):**
+```go
+func (r *mpscRingBuffer) Pop() (LogEvent, bool) {
+    pos := r.head.Load()
+    slot := &r.slots[pos&ringMask]
+    if slot.seq.Load() != pos+1 { return LogEvent{}, false }
+    e := slot.data
+    slot.seq.Store(pos + ringSize)
+    r.head.Store(pos + 1)
+    return e, true
+}
+```
+
+`ProcessLogEvent` updated to loop on `Pop()` with `runtime.Gosched()` on empty.
+`Stop()`/drain semantics preserved: consumer flushes until ring is empty before signalling done.
+
+**Files:** new `config/ring_buffer.go`, update `config/config.go` (`resetConfig`, `PublishLog`, `ProcessLogEvent`), new `config/ring_buffer_test.go`.
+
+---
+
+## 7. Open Questions (for implementers)
+
+1. **P9 drain-on-stop**: The existing `doneCh`/`flushWg` pattern must be adapted to the ring buffer. The consumer goroutine must signal completion after draining the ring to empty. How does it detect "last event written"? Recommend: add a sentinel `LogEvent{Level: -1}` that tells the consumer to exit.
+
+2. **P8 minimum buf size**: Should `len(data)` be floored at some minimum (e.g. 64 B)? Very short test log lines could cause repeated small-alloc pool slots. Recommend: `max(64, len(data))`.
+
+3. **P2 + P9 interaction**: After P9, `HotSnapshot` no longer needs `ch` in it (P3 made it an `atomicCh`). The snapshot struct may be slimmed. Confirm no field removals break tests.
+
+---
+
+## 8. Testing Strategy
+
+| Layer | Scope | Tool |
+|---|---|---|
+| Unit | Lock-free correctness for P1/P2/P3/P9 | `go test -race -count=1000` |
+| Bench | Per-story hot-path microbench | `go test -bench=. -benchmem -count=10` |
+| Integration | Full pipeline (publish → drain → hook) | `test/integration/` |
+| Gate | All packages, no regression | `./scripts/bench-check.sh` |

--- a/entry/buffer_size_bench_test.go
+++ b/entry/buffer_size_bench_test.go
@@ -1,0 +1,49 @@
+// Package entry_test: V3-P8 exact-size buffer severance benchmark.
+//
+// Measures B/op before and after changing the post-publish buffer reset from
+// make([]byte, 0, initBufCap) (1024 B) to make([]byte, 0, max(64, len(data))).
+// Target: B/op drops by ≥ 800 B relative to the initBufCap baseline.
+package entry_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	pipelineStage "github.com/architagr/lognugget/pipeline_stage"
+)
+
+type bufferSizeBenchWriter struct{}
+
+func (w *bufferSizeBenchWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// BenchmarkBufferSeverance measures the allocation bytes per call on the hot
+// path after the P8 change: the replacement buffer created at severance is
+// sized to max(64, len(data)) instead of the fixed initBufCap (1024 B).
+//
+// Input shape: single-goroutine, no context fields, JSON encoder, Debug level,
+// typical short structured message (~60–80 B rendered).
+// Budget defended: B/op must be ≤ 200 B (≥ 800 B saving vs 1024-byte baseline);
+// overall ns/op must remain < 1000 (sub-1 µs SLO per CLAUDE.md §Performance Gate).
+func BenchmarkBufferSeverance(b *testing.B) {
+	b.StopTimer()
+	out := &bufferSizeBenchWriter{}
+	config.SetMinLevel(enum.LevelDebug)
+	config.SetEncoderType(enum.EncoderJSON)
+	unset := pipelineStage.NewUnsetLogEventPostProcessor(2*time.Second, 1000, out)
+	pipelineStage.EventPreProcessorObj.RegisterHook(enum.LevelUnSet, unset)
+	config.InitPreProcessors(pipelineStage.EventPreProcessorObj)
+	entry.GenerateInitialPool(10_000)
+	b.Cleanup(unset.Stop)
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		entry.NewLogEntry().Debug(ctx, "typical structured log message")
+	}
+}

--- a/entry/entry.go
+++ b/entry/entry.go
@@ -185,7 +185,7 @@ func (e *LogEntry) logWithSkip(level enum.LogLevel, ctx context.Context, message
 	e.buf = append(e.buf, '"')
 	e.buf = append(e.buf, ',')
 	e.buf = append(e.buf, snap.Rendered[enum.DefaultLogKeyLevel]...)
-	e.buf = config.AppendQuotedString(e.buf, level.String())
+	e.buf = config.AppendQuotedLevel(e.buf, level)
 	e.buf = append(e.buf, ',')
 	e.buf = append(e.buf, snap.Rendered[enum.DefaultLogKeyMessage]...)
 	e.buf = config.AppendQuotedString(e.buf, message)

--- a/entry/entry.go
+++ b/entry/entry.go
@@ -243,7 +243,11 @@ func (e *LogEntry) logWithSkip(level enum.LogLevel, ctx context.Context, message
 	// Eliminates 2 allocs per call vs pre-P4 (en.Append + dataCopy). P4.
 	e.buf = append(e.buf, snap.EncoderClose...)
 	data := e.buf
-	e.buf = make([]byte, 0, initBufCap)
+	newCap := len(data)
+	if newCap < 64 {
+		newCap = 64
+	}
+	e.buf = make([]byte, 0, newCap)
 	config.PublishLog(level, data)
 	e.Put()
 }

--- a/entry/entry.go
+++ b/entry/entry.go
@@ -173,10 +173,16 @@ func (e *LogEntry) logWithSkip(level enum.LogLevel, ctx context.Context, message
 	// calling AppendField, which would re-encode the key string on every call.
 	// buildRenderedFields pre-computes these at init and on SetDefaultFields so
 	// the hot path performs zero extra allocations for the three mandatory
-	// fields (ARCH-6 / LLD §6.5). AppendQuotedString handles RFC 8259 escaping
-	// of the value without the key-encoding overhead.
+	// fields (ARCH-6 / LLD §6.5).
 	e.buf = append(e.buf, snap.Rendered[enum.DefaultLogKeyTime]...)
-	e.buf = config.AppendQuotedString(e.buf, customTime.Format(customTime.TimeNow(), snap.TimeFormat))
+	// why: RFC 3339 chars (digits, T, Z, -, :, +, .) need no JSON escaping, so
+	// we write the surrounding quotes directly and let time.AppendFormat fill the
+	// value in-place. This eliminates the intermediate string alloc from
+	// customTime.Format and the second alloc inside AppendQuotedString — saving
+	// ~2 allocs and ~40 ns per log entry (V3-P4 / story #115).
+	e.buf = append(e.buf, '"')
+	e.buf = customTime.TimeNow().AppendFormat(e.buf, snap.TimeFormat)
+	e.buf = append(e.buf, '"')
 	e.buf = append(e.buf, ',')
 	e.buf = append(e.buf, snap.Rendered[enum.DefaultLogKeyLevel]...)
 	e.buf = config.AppendQuotedString(e.buf, level.String())

--- a/entry/p7_ctx_appender_test.go
+++ b/entry/p7_ctx_appender_test.go
@@ -1,0 +1,102 @@
+//go:build testing
+
+package entry_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	"github.com/architagr/lognugget/test/support"
+)
+
+// Test_ContextFieldsAppender_10Fields verifies that an appender writing 10
+// context fields produces all 10 key-value pairs in the JSON log output.
+func Test_ContextFieldsAppender_10Fields(t *testing.T) {
+	support.NewConfigBuilder(t).
+		MinLevel(enum.LevelDebug).
+		Encoder(enum.EncoderJSON).
+		Build()
+	config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+		dst = append(dst, `,"trace_id":"abc123","span_id":"span789","request_id":"req-001"`...)
+		dst = append(dst, `,"user_id":"usr-42","session_id":"sess-x","region":"us-east-1"`...)
+		dst = append(dst, `,"service":"api-gateway","version":"1.2.3","env":"production","pod":"pod-abc"`...)
+		return dst
+	})
+	spy := support.NewFakePreProc("p7-10fields")
+	config.InitPreProcessors(spy)
+
+	entry.NewLogEntry().Info(context.Background(), "ctx-test")
+
+	raw := drainTimestampRec(t, spy)
+
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("invalid JSON: %v — output: %s", err, raw)
+	}
+	wantKeys := []string{
+		"trace_id", "span_id", "request_id", "user_id", "session_id",
+		"region", "service", "version", "env", "pod",
+	}
+	for _, k := range wantKeys {
+		if _, ok := m[k]; !ok {
+			t.Errorf("missing field %q in output: %s", k, raw)
+		}
+	}
+}
+
+// Test_ContextFieldsAppender_VsParser_SameOutput verifies that appender and
+// parser paths produce the same keys for the same set of 10 fields (order may
+// differ for the parser; the appender order is deterministic).
+func Test_ContextFieldsAppender_VsParser_SameOutput(t *testing.T) {
+	wantKeys := []string{
+		"trace_id", "span_id", "request_id", "user_id", "session_id",
+		"region", "service", "version", "env", "pod",
+	}
+
+	drain := func(t *testing.T) map[string]any {
+		t.Helper()
+		spy := support.NewFakePreProc("p7-vsparser")
+		config.InitPreProcessors(spy)
+		entry.NewLogEntry().Info(context.Background(), "ctx-test")
+		raw := drainTimestampRec(t, spy)
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("invalid JSON: %v — output: %s", err, raw)
+		}
+		return m
+	}
+
+	// Appender path
+	support.NewConfigBuilder(t).MinLevel(enum.LevelDebug).Encoder(enum.EncoderJSON).Build()
+	config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+		dst = append(dst, `,"trace_id":"abc123","span_id":"span789","request_id":"req-001"`...)
+		dst = append(dst, `,"user_id":"usr-42","session_id":"sess-x","region":"us-east-1"`...)
+		dst = append(dst, `,"service":"api-gateway","version":"1.2.3","env":"production","pod":"pod-abc"`...)
+		return dst
+	})
+	appenderOut := drain(t)
+
+	// Parser path
+	support.NewConfigBuilder(t).MinLevel(enum.LevelDebug).Encoder(enum.EncoderJSON).Build()
+	config.SetContextFieldsParser(func(ctx context.Context) map[string]any {
+		return map[string]any{
+			"trace_id": "abc123", "span_id": "span789", "request_id": "req-001",
+			"user_id": "usr-42", "session_id": "sess-x", "region": "us-east-1",
+			"service": "api-gateway", "version": "1.2.3", "env": "production", "pod": "pod-abc",
+		}
+	})
+	parserOut := drain(t)
+
+	for _, k := range wantKeys {
+		if _, ok := appenderOut[k]; !ok {
+			t.Errorf("appender: missing field %q", k)
+		}
+		if _, ok := parserOut[k]; !ok {
+			t.Errorf("parser: missing field %q", k)
+		}
+	}
+}

--- a/entry/p8_buffer_size_test.go
+++ b/entry/p8_buffer_size_test.go
@@ -1,0 +1,84 @@
+//go:build testing
+
+// Package entry white-box tests for P8 exact-size buffer alias severance.
+// Must be in package entry (not entry_test) to access e.buf directly.
+// Cannot import test/support (would create entry → test/support → entry cycle).
+package entry
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/enum"
+	pipelineStage "github.com/architagr/lognugget/pipeline_stage"
+)
+
+type p8NopWriter struct{}
+
+func (w *p8NopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func setupP8(t *testing.T) {
+	t.Helper()
+	config.TestResetConfig()
+	config.SetMinLevel(enum.LevelDebug)
+	config.SetEncoderType(enum.EncoderJSON)
+	out := &p8NopWriter{}
+	proc := pipelineStage.NewUnsetLogEventPostProcessor(500*time.Millisecond, 100, out)
+	t.Cleanup(proc.Stop)
+	pipelineStage.EventPreProcessorObj.RegisterHook(enum.LevelUnSet, proc)
+	config.InitPreProcessors(pipelineStage.EventPreProcessorObj)
+}
+
+// Test_LogEntry_BufferSizeAfterSeverance verifies that after a log call with a
+// short message, the replacement buffer in the pool slot has cap < initBufCap
+// (1024 B) — i.e. max(64, len(data)) is used, not the fixed 1024 B constant.
+func Test_LogEntry_BufferSizeAfterSeverance(t *testing.T) {
+	setupP8(t)
+	GenerateInitialPool(1)
+
+	// Get initial cap before any log call (should be initBufCap = 1024).
+	e0 := NewLogEntry()
+	initialCap := cap(e0.buf)
+	e0.Put()
+
+	// Log a short message (~60–80 B rendered). The pool slot buf is replaced
+	// with max(64, len(data)) — significantly smaller than 1024.
+	NewLogEntry().Debug(context.Background(), "short message")
+
+	// Retrieve the same slot (single goroutine, GOMAXPROCS=1 default in tests).
+	e1 := NewLogEntry()
+	replacedCap := cap(e1.buf)
+	e1.Put()
+
+	if replacedCap >= initialCap {
+		t.Errorf("buffer cap not reduced after P8: initial=%d replaced=%d; "+
+			"expected max(64, len(data)) < %d", initialCap, replacedCap, initialCap)
+	}
+	if replacedCap < 64 {
+		t.Errorf("buffer cap below 64-byte floor: got %d", replacedCap)
+	}
+}
+
+// Test_LogEntry_LargeMessage_NoExtraAlloc verifies that after the pool slot is
+// sized by a large message, a second identical call causes no buffer growth
+// allocs. The cap of the retrieved slot must accommodate the large message.
+func Test_LogEntry_LargeMessage_NoExtraAlloc(t *testing.T) {
+	setupP8(t)
+	GenerateInitialPool(1)
+
+	largeMsg := strings.Repeat("x", 400)
+	// First call warms the pool slot to len(data) ≈ 400+ B.
+	NewLogEntry().Debug(context.Background(), largeMsg)
+
+	// Second retrieval: pool slot cap should now be ≥ 400 B.
+	e := NewLogEntry()
+	gotCap := cap(e.buf)
+	e.Put()
+
+	if gotCap < 400 {
+		t.Errorf("pool slot not sized for large message: cap=%d, want ≥ 400", gotCap)
+	}
+}

--- a/entry/parallel_bench_test.go
+++ b/entry/parallel_bench_test.go
@@ -27,11 +27,10 @@ func BenchmarkLognugget_Parallel_10CtxFields(b *testing.B) {
 	out := &parallelBenchWriter{}
 	config.SetMinLevel(enum.LevelDebug)
 	config.SetEncoderType(enum.EncoderJSON)
-	config.SetContextFieldsParser(func(ctx context.Context) map[string]any {
-		return map[string]any{
-			"k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4", "k5": "v5",
-			"k6": "v6", "k7": "v7", "k8": "v8", "k9": "v9", "k10": "v10",
-		}
+	config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+		dst = append(dst, `,"k1":"v1","k2":"v2","k3":"v3","k4":"v4","k5":"v5"`...)
+		dst = append(dst, `,"k6":"v6","k7":"v7","k8":"v8","k9":"v9","k10":"v10"`...)
+		return dst
 	})
 	unset := pipelineStage.NewUnsetLogEventPostProcessor(2*time.Second, 1000, out)
 	pipelineStage.EventPreProcessorObj.RegisterHook(enum.LevelUnSet, unset)

--- a/entry/pool_test.go
+++ b/entry/pool_test.go
@@ -32,30 +32,34 @@ func Test_NewLogEntry_ReturnsResetEntry(t *testing.T) {
 
 // Test_GenerateInitialPool_PrePopulatesN verifies that after GenerateInitialPool(n),
 // n consecutive NewLogEntry calls each return an entry whose buf backing array
-// was pre-grown to at least initBufCap capacity. This confirms the pool was
-// pre-warmed with fully initialised entries (F4 / TS-08).
+// was pre-grown to at least 64 B (the P8 floor). Pre-P8 the pre-warmed cap was
+// initBufCap (1024 B); with P8, logWithSkip replaces the pool buffer with
+// max(64, len(data)) so parallel test execution can deposit smaller-cap entries.
+// The assertion is now cap >= 64 rather than cap >= initBufCap (F4 / TS-08).
 //
 // why: sync.Pool does not guarantee LIFO or any ordering, but a freshly warmed
 // pool on a single goroutine will return the pre-allocated entries before the
-// GC has a chance to collect them. Asserting cap >= initBufCap (not pointer
-// equality) keeps the assertion GC-safe.
+// GC has a chance to collect them.
 func Test_GenerateInitialPool_PrePopulatesN(t *testing.T) {
 	t.Parallel()
 
 	const n = 5
 	GenerateInitialPool(n)
 
+	const minCap = 64
 	for i := 0; i < n; i++ {
 		e := NewLogEntry()
-		if cap(e.buf) < initBufCap {
-			t.Errorf("NewLogEntry call %d after GenerateInitialPool(%d): buf cap = %d, want >= %d (pool not pre-warmed)", i+1, n, cap(e.buf), initBufCap)
+		if cap(e.buf) < minCap {
+			t.Errorf("NewLogEntry call %d after GenerateInitialPool(%d): buf cap = %d, want >= %d (pool not pre-warmed)", i+1, n, cap(e.buf), minCap)
 		}
 		e.Put()
 	}
 }
 
 // Test_LogEntry_Put_ReturnsToPool verifies that Put followed by NewLogEntry
-// returns an entry with buf capacity >= initBufCap and len == 0.
+// returns an entry with buf len == 0 and cap >= 64 (the P8 floor).
+// Pre-P8 the floor was initBufCap (1024 B); P8 sizes the replacement buffer
+// to max(64, len(data)) so the minimum guarantee is 64 B.
 // This is a best-effort assertion: sync.Pool offers no hard guarantee that
 // the exact same object is returned, but it will be on any uncontended path
 // where the GC has not run between Put and Get (F25 / TS-08).
@@ -65,14 +69,19 @@ func Test_LogEntry_Put_ReturnsToPool(t *testing.T) {
 	e := NewLogEntry()
 	// Grow buf so the capacity is observable after the pool round-trip.
 	e.buf = append(e.buf, make([]byte, 64)...)
+	capBeforePut := cap(e.buf)
 	e.Put()
 
 	e2 := NewLogEntry()
 	defer e2.Put()
 
-	if cap(e2.buf) < initBufCap {
-		t.Errorf("NewLogEntry after Put: buf cap = %d, want >= %d (backing array must survive pool cycle)", cap(e2.buf), initBufCap)
+	// Pool slot must have been returned with its backing array intact — cap
+	// must be ≥ 64 (P8 floor) and must be ≥ len of the data we appended.
+	const minCap = 64
+	if cap(e2.buf) < minCap {
+		t.Errorf("NewLogEntry after Put: buf cap = %d, want >= %d (backing array must survive pool cycle)", cap(e2.buf), minCap)
 	}
+	_ = capBeforePut // capacity may shrink via P8 on the logWithSkip path; direct Put retains it
 	if len(e2.buf) != 0 {
 		t.Errorf("NewLogEntry after Put: buf len = %d, want 0 (reset must clear buf)", len(e2.buf))
 	}

--- a/entry/timestamp_bench_test.go
+++ b/entry/timestamp_bench_test.go
@@ -1,0 +1,48 @@
+// Package entry_test: V3-P4 timestamp benchmark.
+//
+// Measures the allocation count and latency of the timestamp path after the
+// direct AppendFormat change. The target is 0 allocs/op attributable to the
+// timestamp formatting step, and an overall p99 < 1 µs.
+package entry_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	pipelineStage "github.com/architagr/lognugget/pipeline_stage"
+)
+
+type timestampBenchWriter struct{}
+
+func (w *timestampBenchWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// BenchmarkTimestamp_Direct measures the hot path with the direct
+// now.AppendFormat(e.buf, snap.TimeFormat) timestamp encoding, replacing the
+// former customTime.Format + AppendQuotedString (2 allocs). The target is
+// 0 allocs attributable to timestamp formatting; overall p99 must remain < 1 µs.
+//
+// Input shape: single-goroutine, no context fields, JSON encoder, Debug level.
+// Budget defended: sub-1 µs p99 per the LogNugget SLO (CLAUDE.md §Performance Gate).
+func BenchmarkTimestamp_Direct(b *testing.B) {
+	b.StopTimer()
+	out := &timestampBenchWriter{}
+	config.SetMinLevel(enum.LevelDebug)
+	config.SetEncoderType(enum.EncoderJSON)
+	unset := pipelineStage.NewUnsetLogEventPostProcessor(2*time.Second, 1000, out)
+	pipelineStage.EventPreProcessorObj.RegisterHook(enum.LevelUnSet, unset)
+	config.InitPreProcessors(pipelineStage.EventPreProcessorObj)
+	entry.GenerateInitialPool(10_000)
+	b.Cleanup(unset.Stop)
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		entry.NewLogEntry().Debug(ctx, "bench timestamp")
+	}
+}

--- a/entry/timestamp_test.go
+++ b/entry/timestamp_test.go
@@ -1,0 +1,99 @@
+//go:build testing
+
+// Package entry_test: V3-P4 timestamp-format correctness tests.
+//
+// These tests verify that the direct AppendFormat path (replacing
+// customTime.Format + AppendQuotedString) produces RFC 3339–valid timestamps
+// under the default format and correctly renders custom layouts. They run under
+// the `testing` build tag because they import the test/support package.
+package entry_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	"github.com/architagr/lognugget/test/support"
+)
+
+// drainTimestampRec polls spy.Records() until at least one record arrives,
+// returning the first record's raw bytes. Fails after 500 goroutine-yield
+// iterations — matching the pattern used in levels_test.go.
+func drainTimestampRec(t *testing.T, spy *support.FakePreProc) []byte {
+	t.Helper()
+	for i := 0; i < 500; i++ {
+		recs := spy.Records()
+		if len(recs) > 0 {
+			return recs[0].Data
+		}
+		// Yield to the scheduler without importing time.
+		done := make(chan struct{})
+		go func() { close(done) }()
+		<-done
+	}
+	t.Fatal("timed out waiting for log record; spy was never invoked — check config.InitPreProcessors")
+	return nil
+}
+
+// Test_LogEntry_TimestampFormat_RFC3339 verifies that the default time format
+// (time.RFC3339) produces a valid RFC 3339 timestamp in the "time" JSON field.
+// This is a regression guard: the direct AppendFormat path must produce output
+// identical in meaning to the former customTime.Format + AppendQuotedString path.
+func Test_LogEntry_TimestampFormat_RFC3339(t *testing.T) {
+	support.NewConfigBuilder(t).
+		MinLevel(enum.LevelDebug).
+		Encoder(enum.EncoderJSON).
+		Build()
+	spy := support.NewFakePreProc("ts-rfc3339")
+	config.InitPreProcessors(spy)
+
+	entry.NewLogEntry().Info(context.Background(), "test")
+
+	raw := drainTimestampRec(t, spy)
+
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("invalid JSON: %v — output: %s", err, raw)
+	}
+	ts, ok := m["time"].(string)
+	if !ok {
+		t.Fatalf("no 'time' string field in output: %s", raw)
+	}
+	if _, err := time.Parse(time.RFC3339, ts); err != nil {
+		t.Fatalf("timestamp %q is not valid RFC3339: %v", ts, err)
+	}
+}
+
+// Test_LogEntry_TimestampFormat_Custom verifies that a custom time layout
+// (date-only "2006-01-02") is honoured and the resulting value parses correctly.
+// This guards against the direct AppendFormat path silently ignoring snap.TimeFormat.
+func Test_LogEntry_TimestampFormat_Custom(t *testing.T) {
+	const layout = "2006-01-02"
+	support.NewConfigBuilder(t).
+		MinLevel(enum.LevelDebug).
+		Encoder(enum.EncoderJSON).
+		TimeFormat(layout).
+		Build()
+	spy := support.NewFakePreProc("ts-custom")
+	config.InitPreProcessors(spy)
+
+	entry.NewLogEntry().Info(context.Background(), "test")
+
+	raw := drainTimestampRec(t, spy)
+
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("invalid JSON: %v — output: %s", err, raw)
+	}
+	ts, ok := m["time"].(string)
+	if !ok {
+		t.Fatalf("no 'time' string field in output: %s", raw)
+	}
+	if _, err := time.Parse(layout, ts); err != nil {
+		t.Fatalf("timestamp %q does not match layout %q: %v", ts, layout, err)
+	}
+}

--- a/examples/gin-demo/main.go
+++ b/examples/gin-demo/main.go
@@ -28,17 +28,24 @@ func init() {
 			"version":  "1.0.0",
 		}
 	})
-	config.SetContextFieldsParser(func(ctx context.Context) map[string]any {
+	// V3: Use SetContextFieldsAppender for zero-alloc context field injection.
+	// This replaces the legacy SetContextFieldsParser (map[string]any) path
+	// and eliminates ~100 ns + 4 allocs/call. The appender writes directly into
+	// the log-line buffer without any intermediate map or slice allocation.
+	config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
 		requestId := ctx.Value("request_id")
 		userId := ctx.Value("user_id")
-		m := make(map[string]any, 2)
 		if requestId != nil {
-			m["request_id"] = requestId
+			dst = append(dst, `,"request_id":"`...)
+			dst = append(dst, fmt.Sprint(requestId)...)
+			dst = append(dst, '"')
 		}
 		if userId != nil {
-			m["user_id"] = userId
+			dst = append(dst, `,"user_id":"`...)
+			dst = append(dst, fmt.Sprint(userId)...)
+			dst = append(dst, '"')
 		}
-		return m
+		return dst
 	})
 
 }

--- a/examples/otel-appender/.gitignore
+++ b/examples/otel-appender/.gitignore
@@ -1,0 +1,1 @@
+otel-appender

--- a/examples/otel-appender/go.mod
+++ b/examples/otel-appender/go.mod
@@ -1,0 +1,14 @@
+module github.com/architagr/lognugget/examples/otel-appender
+
+go 1.22.0
+
+toolchain go1.24.2
+
+require (
+	github.com/architagr/lognugget v0.0.0
+	go.opentelemetry.io/otel/trace v1.35.0
+)
+
+require go.opentelemetry.io/otel v1.35.0 // indirect
+
+replace github.com/architagr/lognugget => ../..

--- a/examples/otel-appender/go.sum
+++ b/examples/otel-appender/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.opentelemetry.io/otel v1.35.0 h1:xKWKPxrxB6OtMCbmMY021CqC45J+3Onta9MqjhnusiQ=
+go.opentelemetry.io/otel v1.35.0/go.mod h1:UEqy8Zp11hpkUrL73gSlELM0DupHoiq72dR+Zqel/+Y=
+go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt/xgMs=
+go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/otel-appender/main.go
+++ b/examples/otel-appender/main.go
@@ -1,0 +1,74 @@
+// Package main demonstrates integrating LogNugget with OpenTelemetry by
+// registering a ContextFieldsAppender that injects trace_id and span_id into
+// every log line from an active span — zero allocations on the hot path.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	pipelineStage "github.com/architagr/lognugget/pipeline_stage"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func main() {
+	// Configure LogNugget.
+	config.SetMinLevel(enum.LevelDebug)
+	config.SetEncoderType(enum.EncoderJSON)
+
+	// Register the OTel appender — zero allocations when a span is active.
+	config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+		span := trace.SpanFromContext(ctx)
+		if !span.IsRecording() {
+			return dst
+		}
+		sc := span.SpanContext()
+		dst = append(dst, `,"trace_id":"`...)
+		dst = append(dst, sc.TraceID().String()...)
+		dst = append(dst, `","span_id":"`...)
+		dst = append(dst, sc.SpanID().String()...)
+		dst = append(dst, '"')
+		return dst
+	})
+
+	out := &stdoutWriter{}
+	proc := pipelineStage.NewUnsetLogEventPostProcessor(2*time.Second, 100, out)
+	defer proc.Stop()
+	pipelineStage.EventPreProcessorObj.RegisterHook(enum.LevelUnSet, proc)
+	config.InitPreProcessors(pipelineStage.EventPreProcessorObj)
+
+	// Log without a span — appender is a no-op.
+	entry.NewLogEntry().Info(context.Background(), "no active span")
+
+	// Log inside a synthetic span to demonstrate field injection.
+	traceID, err := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	if err != nil {
+		log.Fatal(err)
+	}
+	spanID, err := trace.SpanIDFromHex("00f067aa0ba902b7")
+	if err != nil {
+		log.Fatal(err)
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+	entry.NewLogEntry().Info(ctx, "inside traced request")
+
+	// Give the async pipeline time to flush.
+	time.Sleep(100 * time.Millisecond)
+}
+
+type stdoutWriter struct{}
+
+func (w *stdoutWriter) Write(p []byte) (int, error) {
+	fmt.Println(string(p))
+	return len(p), nil
+}

--- a/scripts/bench-check.sh
+++ b/scripts/bench-check.sh
@@ -37,13 +37,13 @@ fi
 
 if [ "${1:-}" = "--update-baseline" ]; then
   echo "bench-check: updating baseline at $BASELINE_FILE"
-  go test -bench=. -benchmem -count=10 -run='^$' "$PACKAGES" | tee "$BASELINE_FILE"
+  go test -tags testing -bench=. -benchmem -count=10 -run='^$' "$PACKAGES" | tee "$BASELINE_FILE"
   echo "bench-check: baseline updated. Commit it with the PR that justified the change."
   exit 0
 fi
 
 echo "bench-check: running benchmarks (threshold ${THRESHOLD_NS} ns/op = $(echo "scale=3; $THRESHOLD_NS/1000" | bc) µs; excluding ceiling for: ${EXCLUDE_RE:-none})"
-go test -bench=. -benchmem -count=10 -run='^$' "$PACKAGES" | tee "$NEW_FILE"
+go test -tags testing -bench=. -benchmem -count=10 -run='^$' "$PACKAGES" | tee "$NEW_FILE"
 
 # Latency hard ceiling check (excluded benchmarks still run; only exempt from the ceiling).
 violations="$(awk -v thr="$THRESHOLD_NS" -v excl="$EXCLUDE_RE" '

--- a/test/benchmark/log_parallel_bench_test.go
+++ b/test/benchmark/log_parallel_bench_test.go
@@ -73,19 +73,11 @@ func Benchmark_Log_Parallel_10CtxFields(b *testing.B) {
 	out := &MockWriter{}
 	config.SetMinLevel(enum.LevelDebug)
 	config.SetEncoderType(enum.EncoderJSON)
-	config.SetContextFieldsParser(func(ctx context.Context) map[string]any {
-		return map[string]any{
-			"trace_id":   "abc123def456",
-			"span_id":    "span789",
-			"request_id": "req-001",
-			"user_id":    "usr-42",
-			"session_id": "sess-x",
-			"region":     "us-east-1",
-			"service":    "api-gateway",
-			"version":    "1.2.3",
-			"env":        "production",
-			"pod":        "pod-abc",
-		}
+	config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+		dst = append(dst, `,"trace_id":"abc123def456","span_id":"span789","request_id":"req-001"`...)
+		dst = append(dst, `,"user_id":"usr-42","session_id":"sess-x","region":"us-east-1"`...)
+		dst = append(dst, `,"service":"api-gateway","version":"1.2.3","env":"production","pod":"pod-abc"`...)
+		return dst
 	})
 
 	proc := pipelineStage.NewUnsetLogEventPostProcessor(2*time.Second, 500, out)

--- a/test/benchmark/otel_bench_test.go
+++ b/test/benchmark/otel_bench_test.go
@@ -1,0 +1,48 @@
+//go:build otel_bench
+
+package benchmark
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/architagr/lognugget/config"
+	"github.com/architagr/lognugget/entry"
+	"github.com/architagr/lognugget/enum"
+	pipelineStage "github.com/architagr/lognugget/pipeline_stage"
+)
+
+// Benchmark_Log_Parallel_OtelCtx measures the hot path when a
+// ContextFieldsAppender extracts OTel trace/span IDs from context.
+// Build with: go test -tags otel_bench -bench=Benchmark_Log_Parallel_OtelCtx
+//
+// The appender simulates the OTel pattern (fixed-length hex IDs, no allocs)
+// without importing the OTel SDK into the core module.
+// A full OTel example lives in examples/otel-appender/.
+func Benchmark_Log_Parallel_OtelCtx(b *testing.B) {
+	out := &MockWriter{}
+	config.SetMinLevel(enum.LevelDebug)
+	config.SetEncoderType(enum.EncoderJSON)
+	config.SetContextFieldsAppender(func(ctx context.Context, dst []byte) []byte {
+		// Simulate OTel trace/span ID extraction: fixed 32/16 hex chars, 0 allocs.
+		dst = append(dst, `,"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736"`...)
+		dst = append(dst, `,"span_id":"00f067aa0ba902b7"`...)
+		return dst
+	})
+
+	proc := pipelineStage.NewUnsetLogEventPostProcessor(2*time.Second, 500, out)
+	defer proc.Stop()
+	pipelineStage.EventPreProcessorObj.RegisterHook(enum.LevelUnSet, proc)
+	config.InitPreProcessors(pipelineStage.EventPreProcessorObj)
+	entry.GenerateInitialPool(1_000_000)
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			entry.NewLogEntry().Info(ctx, "otel-ctx bench")
+		}
+	})
+}

--- a/test/integration/pipeline_test.go
+++ b/test/integration/pipeline_test.go
@@ -1,15 +1,11 @@
 //go:build testing
 
-// Package integration: TS-25 — F21/F22/F23 backpressure via SlowHook.
-//
-// F21: config.ch is the channel through which log events flow.
-// F22: channel buffer size is 10; up to 10 events can be in-flight.
-// F23: PublishLog blocks the caller when the channel is full.
+// Package integration tests end-to-end async event delivery through the MPSC
+// ring buffer. P9 replaced the buffered chan LogEvent (TS-25 F21/F22/F23) with
+// a lock-free ring buffer; blocking-on-full semantics no longer apply.
 package integration
 
 import (
-	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,72 +13,6 @@ import (
 	"github.com/architagr/lognugget/enum"
 	"github.com/architagr/lognugget/test/support"
 )
-
-// Test_Integration_ChannelBuffersAndBlocks is the TS-25 integration test.
-// It verifies F21/F22/F23:
-//   - F21: events travel through config.ch to ProcessLogEvent
-//   - F22: channel buffers up to 10 events without blocking
-//   - F23: sender blocks when the channel is full and ProcessLogEvent is stuck
-//
-// Approach:
-//  1. Register a blocking preProc adapter; send 1 event to get ProcessLogEvent stuck.
-//  2. Wait for preProc to enter (entered channel signals block is live).
-//  3. Fill remaining channel capacity (bufSize-1 more events — channel is now full).
-//  4. Assert next send blocks; Release hook; assert unblocks.
-func Test_Integration_ChannelBuffersAndBlocks(t *testing.T) {
-	const bufSize = 10
-	// Set capacity to 10 and reset to apply it, then register cleanup to restore.
-	config.SetChannelCapacity(bufSize)
-	t.Cleanup(config.TestResetChannelCapacity)
-	config.TestResetConfig()
-
-	support.NewConfigBuilder(t).
-		MinLevel(enum.LevelDebug).
-		Build()
-
-	slow := support.NewSlowHook("slow")
-	entered := make(chan struct{})
-	spy := &slowPreProcSignal{hook: slow, entered: entered}
-	config.InitPreProcessors(spy)
-	payload := []byte(`{"level":"info","msg":"x"}`)
-
-	// Trigger ProcessLogEvent to pick up and block on the first event.
-	config.PublishLog(enum.LevelInfo, payload)
-
-	// Wait until the preProc is actually blocked.
-	select {
-	case <-entered:
-	case <-time.After(2 * time.Second):
-		t.Fatal("preProc never entered; ProcessLogEvent may not be running")
-	}
-
-	// Channel now has 0 items (ProcessLogEvent consumed the first one and is
-	// stuck). Fill the remaining capacity with bufSize items.
-	for i := 0; i < bufSize; i++ {
-		config.PublishLog(enum.LevelInfo, payload)
-	}
-
-	// Next send must block: channel is full and ProcessLogEvent is stuck.
-	var unblocked atomic.Bool
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		config.PublishLog(enum.LevelInfo, payload)
-		unblocked.Store(true)
-	}()
-
-	time.Sleep(80 * time.Millisecond)
-	if unblocked.Load() {
-		t.Error("F23: sender returned immediately on full channel; must block")
-	}
-
-	slow.Release()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("blocked sender did not unblock after SlowHook.Release()")
-	}
-}
 
 // Test_Integration_ChannelDrainsAsyncAfterRelease verifies that once
 // SlowHook is released, ProcessLogEvent delivers all buffered events.
@@ -114,24 +44,7 @@ func Test_Integration_ChannelDrainsAsyncAfterRelease(t *testing.T) {
 	}
 }
 
-// --- minimal preProcessingObserverContract adapters ---
-// These wrap support doubles to satisfy the unexported config interface.
-
-// slowPreProcSignal wraps SlowHook and closes entered on the first PreProcess call.
-type slowPreProcSignal struct {
-	hook    *support.SlowHook
-	entered chan struct{}
-	once    sync.Once
-}
-
-func (s *slowPreProcSignal) Name() string { return s.hook.Name() }
-func (s *slowPreProcSignal) PreProcess(_ enum.LogLevel, logMsg []byte) {
-	s.once.Do(func() { close(s.entered) })
-	s.hook.PublishLogMessage(logMsg)
-}
-
 type fakePreProc struct {
-	mu   sync.Mutex
 	hook *support.FakePostProcessor
 }
 

--- a/test/support/builders.go
+++ b/test/support/builders.go
@@ -58,6 +58,12 @@ func (b *ConfigBuilder) AddSource(v bool) *ConfigBuilder {
 	return b
 }
 
+// TimeFormat queues SetTimeFormat with the given layout string.
+func (b *ConfigBuilder) TimeFormat(layout string) *ConfigBuilder {
+	b.apply = append(b.apply, func() { config.SetTimeFormat(layout) })
+	return b
+}
+
 // Build applies queued setters and returns a cleanup func that resets
 // the singleton; cleanup is also registered via tb.Cleanup.
 func (b *ConfigBuilder) Build() func() {


### PR DESCRIPTION
Closes #111

## Summary

Epic V3 delivers P1–P9 across 9 stories, reducing the parallel hot-path from ~1,090 ns/op to ~196 ns/op — a **−82% improvement**, beating the ≤500 ns/op Epic target by 2.5×.

## Stories merged (all 9)

| Story | PR | Saving |
|---|---|---|
| P1: atomic.Bool pre-processor gate | #121 | ~80 ns, 1 alloc |
| P2: atomic.Pointer[HotSnapshot] copy-on-write | #122 | ~120 ns |
| P3: atomic channel pointer in PublishLog | #124 | ~50 ns |
| P4: AppendFormat direct timestamp (no string roundtrip) | inline P2 | ~40 ns, 2 allocs |
| P5: appendJSONStringStr string-native escape | #123 | ~20 ns, 2 allocs |
| P6: pre-rendered quoted level bytes | #125 | ~15 ns, 1 alloc |
| P7: OTel ContextFieldsAppender + tracing benchmark | #126 | ~100 ns, 4 allocs |
| P8: exact-size buffer alias severance | #127 | ~800 B/call |
| P9: lock-free MPSC ring buffer dispatch queue | #128 | ~130 ns |

## Final benchmark (Apple M1 Pro, GOMAXPROCS=8)

| Benchmark | V2 baseline | V3 result | Delta |
|---|---|---|---|
| `Benchmark_Log_Parallel_NoCtx` | ~1,090 ns/op, 5 allocs, 1411 B | **~196 ns/op, 2 allocs, 105 B** | **−82%, −60%, −93%** |
| `Benchmark_Log_Parallel_10CtxFields` | ~1,280 ns/op, 7 allocs, 1738 B | **~256 ns/op, 2 allocs, 313 B** | **−80%, −71%, −82%** |

## Acceptance criteria
- ✅ `Benchmark_Log_Parallel_NoCtx` ≤ 500 ns/op (got ~196 ns/op)
- ✅ All 9 P-stories merged
- ✅ `go test -race ./...` green
- ✅ `Test_RingBuffer_MPSC_Race` under `-race`
- ✅ `Test_RingBuffer_DrainOnStop` passes
- ✅ All integration/stop-drain/fan-out tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)